### PR TITLE
Fix webhook URL config

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from aiohttp import web, ClientSession
 logging.basicConfig(level=logging.INFO)
 
 DB_PATH = os.getenv("DB_PATH", "bot.db")
-WEBHOOK_URL = os.getenv("WEBHOOK_URL", "https://telegram-post-scheduler.fly.dev")
 TZ_OFFSET = os.getenv("TZ_OFFSET", "+00:00")
 SCHED_INTERVAL_SEC = int(os.getenv("SCHED_INTERVAL_SEC", "30"))
 
@@ -726,7 +725,9 @@ def create_app():
 
     app.router.add_post('/webhook', handle_webhook)
 
-    webhook_base = WEBHOOK_URL
+    webhook_base = os.getenv("WEBHOOK_URL")
+    if not webhook_base:
+        raise RuntimeError("WEBHOOK_URL not found in environment variables")
 
     async def start_background(app: web.Application):
         logging.info("Application startup")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from main import create_app, Bot
 
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+os.environ.setdefault("WEBHOOK_URL", "https://example.com")
 
 @pytest.mark.asyncio
 async def test_startup_cleanup():


### PR DESCRIPTION
## Summary
- remove default webhook URL
- require `WEBHOOK_URL` env var in `create_app`
- update tests to set `WEBHOOK_URL`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685c781edf8c833282009e1435dc6a88