### PR TITLE
Implement /addbutton command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - User lists show clickable usernames for easy profile access.
 - Local timezone support for scheduling.
 - Configurable scheduler interval.
+- Add inline buttons to existing posts.
 
 
 ## Commands
@@ -24,6 +25,7 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - /scheduled - show scheduled posts with target channel names
 - /history - recent posts
 - /tz <offset> - set timezone offset (e.g., +02:00)
+- /addbutton <post_url> <text> <url> - add inline button to existing post (button text may contain spaces)
 
 ## User Stories
 
@@ -35,7 +37,8 @@ This bot allows authorized users to schedule posts to their Telegram channels.
   inline approval buttons.
 - **US-4**: Channel listener events and `/channels` command.
 - **US-5**: Post scheduling interface with channel selection, cancellation and rescheduling. Scheduled list shows the post preview or link along with the target channel name and time in HH:MM DD.MM.YYYY format.
- - **US-6**: Scheduler forwards queued posts at the correct local time. If forwarding fails because the bot is not a member, it falls back to copying. Interval is configurable and all actions are logged.
+- **US-6**: Scheduler forwards queued posts at the correct local time. If forwarding fails because the bot is not a member, it falls back to copying. Interval is configurable and all actions are logged.
+- **US-8**: `/addbutton <post_url> <text> <url>` adds an inline button to an existing channel post. Update logged with INFO level.
 
 ### In Progress
 - **US-7**: Logging of all operations.

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 import sqlite3
 from datetime import datetime, date, timedelta, timezone
 import contextlib
+import re
 
 from aiohttp import web, ClientSession
 
@@ -225,6 +226,18 @@ class Bot:
     def is_superadmin(self, user_id):
         row = self.get_user(user_id)
         return row and row['is_superadmin']
+
+    async def parse_post_url(self, url: str) -> tuple[int, int] | None:
+        """Return chat_id and message_id from a Telegram post URL."""
+        m = re.search(r"/c/(\d+)/(\d+)", url)
+        if m:
+            return int(f"-100{m.group(1)}"), int(m.group(2))
+        m = re.search(r"t.me/([^/]+)/(\d+)", url)
+        if m:
+            resp = await self.api_request('getChat', {'chat_id': f"@{m.group(1)}"})
+            if resp.get('ok'):
+                return resp['result']['id'], int(m.group(2))
+        return None
 
     async def handle_message(self, message):
         text = message.get('text', '')
@@ -475,6 +488,37 @@ class Bot:
                     'text': f"{r['id']}: {target} at {self.format_time(r['publish_time'], offset)}",
                     'reply_markup': keyboard
                 })
+            return
+
+        if text.startswith('/addbutton'):
+            if not self.is_authorized(user_id):
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Not authorized'})
+                return
+            parts = text.split()
+            if len(parts) < 4:
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'Usage: /addbutton <post_url> <text> <url>'
+                })
+                return
+            parsed = await self.parse_post_url(parts[1])
+            if not parsed:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Invalid post URL'})
+                return
+            chat_id, msg_id = parsed
+            keyboard_text = " ".join(parts[2:-1])
+            keyboard = {'inline_keyboard': [[{'text': keyboard_text, 'url': parts[-1]}]]}
+            resp = await self.api_request('editMessageReplyMarkup', {
+                'chat_id': chat_id,
+                'message_id': msg_id,
+                'reply_markup': keyboard
+            })
+            if resp.get('ok'):
+                logging.info('Updated message %s with button', msg_id)
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Button added'})
+            else:
+                logging.error('Failed to add button to %s: %s', msg_id, resp)
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Failed to add button'})
             return
 
         # handle time input for scheduling

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -289,3 +289,45 @@ async def test_scheduler_process_due(tmp_path):
     assert calls[-1][0] == "forwardMessage"
 
     await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_add_button(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        if method == "getChat":
+            return {"ok": True, "result": {"id": -100123}}
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    await bot.handle_update({
+        "message": {
+            "text": "/addbutton https://t.me/c/123/5 btn https://example.com",
+            "from": {"id": 1},
+        }
+    })
+
+    assert any(c[0] == "editMessageReplyMarkup" for c in calls)
+
+    await bot.handle_update({
+        "message": {
+            "text": "/addbutton https://t.me/c/123/5 ask locals https://example.com",
+            "from": {"id": 1},
+        }
+    })
+
+    # check that button text with spaces is parsed correctly
+    edit_calls = [c for c in calls if c[0] == "editMessageReplyMarkup"]
+    assert len(edit_calls) == 2
+    payload = edit_calls[-1][1]
+    assert payload["reply_markup"]["inline_keyboard"][0][0]["text"] == "ask locals"
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- extend documentation with inline button feature
- handle `/addbutton` command in bot
- support parsing Telegram message URLs
- test adding button to a post
- handle multi-word button text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685c7e0df1d883328e84bca8a6b83570