### PR TITLE
Implement weather now option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - **US-9**: `/delbutton <post_url>` removes inline buttons from an existing channel post.
 - **US-10**: Admin adds a city with `/addcity`.
 - **US-11**: Admin views and removes cities with `/cities`.
+- **US-12**: Periodic weather collection from Open-Meteo with up to three retries on failure.
+- **US-13**: Admin requests last weather check info and can force an update.
 
 ### In Progress
 - **US-7**: Logging of all operations.
 
 ### Planned
-- **US-12**: Periodic weather collection from Open-Meteo.
-- **US-13**: Admin requests last weather check info.
 - **US-14**: Admin registers a weather post for updates.
 - **US-15**: Automatic weather post updates.
 - **US-16**: Admin lists registered posts.

--- a/architectural_overview.md
+++ b/architectural_overview.md
@@ -13,7 +13,7 @@ The database is migrated via SQL files in the `migrations` folder.
 Handles Telegram updates and user commands.
 
 ### 3.2 WeatherService
-Collects current and forecast weather data from Open-Meteo for registered cities. It writes results to `weather_cache` and provides information for post templates.
+Collects current weather data from Open-Meteo for registered cities each hour. Results are stored in `weather_cache` and logged. Failed requests are retried up to three times with a minute pause, after which the service waits until the next hour. The bot ignores API errors so it continues running.
 
 ### 3.3 Webhook
 The HTTP server receives Telegram webhooks.
@@ -32,7 +32,7 @@ The application targets Fly.io free tier and runs a single process.
 - US-10: admin adds a city.
 - US-11: admin views and removes cities.
 - US-12: periodic weather collection from Open-Meteo.
-- US-13: admin requests last weather check info.
+- US-13: admin requests last weather check info and can force an update.
 - US-14: admin registers a weather post for updates.
 - US-15: automatic weather post updates.
 - US-16: admin lists registered posts.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -2,6 +2,12 @@
 
 This document describes the weather feature set for the Telegram scheduler bot.
 
+Weather for each city is queried from the Open-Meteo API approximately once per
+hour and stored in the `weather_cache` table. The bot logs all requests and
+continues working even if a query fails. When a request fails, it is retried up
+to three times with a one‑minute pause between attempts. After that, no further
+requests are made for that city until the next scheduled hour.
+
 
 ## Commands
 
@@ -11,6 +17,9 @@ This document describes the weather feature set for the Telegram scheduler bot.
 - `/cities` – list registered cities. Each entry has an inline *Delete* button that
   removes the city from the list. Coordinates are displayed with six decimal digits
   to reflect the stored precision.
+- `/weather` – show the last collected weather for all cities. Only superadmins may
+  request this information. Append `now` to force a fresh API request before
+  displaying results.
 
 
 ## Database schema

--- a/main.py
+++ b/main.py
@@ -14,6 +14,30 @@ logging.basicConfig(level=logging.INFO)
 DB_PATH = os.getenv("DB_PATH", "bot.db")
 TZ_OFFSET = os.getenv("TZ_OFFSET", "+00:00")
 SCHED_INTERVAL_SEC = int(os.getenv("SCHED_INTERVAL_SEC", "30"))
+WMO_EMOJI = {
+    0: "\u2600\ufe0f",
+    1: "\U0001F324",
+    2: "\u26c5",
+    3: "\u2601\ufe0f",
+    45: "\U0001F32B",
+    48: "\U0001F32B",
+    51: "\U0001F327",
+    53: "\U0001F327",
+    55: "\U0001F327",
+    61: "\U0001F327",
+    63: "\U0001F327",
+    65: "\U0001F327",
+    71: "\u2744\ufe0f",
+    73: "\u2744\ufe0f",
+    75: "\u2744\ufe0f",
+    80: "\U0001F327",
+    81: "\U0001F327",
+    82: "\U0001F327",
+    95: "\u26c8\ufe0f",
+    96: "\u26c8\ufe0f",
+    99: "\u26c8\ufe0f",
+}
+
 
 CREATE_TABLES = [
     """CREATE TABLE IF NOT EXISTS users (
@@ -97,6 +121,7 @@ class Bot:
                 self.db.execute(f"ALTER TABLE {table} ADD COLUMN {column} TEXT")
         self.db.commit()
         self.pending = {}
+        self.failed_fetches: dict[int, tuple[int, datetime]] = {}
         self.session: ClientSession | None = None
         self.running = False
 
@@ -126,6 +151,75 @@ class Bot:
             else:
                 logging.info("API call %s succeeded", method)
             return result
+
+    async def fetch_open_meteo(self, lat: float, lon: float) -> dict | None:
+        url = (
+            "https://api.open-meteo.com/v1/forecast?latitude="
+            f"{lat}&longitude={lon}&current_weather=true"
+        )
+        try:
+            async with self.session.get(url) as resp:
+                text = await resp.text()
+                if resp.status != 200:
+                    logging.error("Open-Meteo HTTP %s: %s", resp.status, text)
+                    return None
+                data = json.loads(text)
+        except Exception:
+            logging.exception("Failed to fetch weather")
+            return None
+        logging.info("Weather response: %s", data.get("current"))
+        return data
+
+    async def collect_weather(self, force: bool = False):
+        cur = self.db.execute("SELECT id, lat, lon FROM cities")
+        for c in cur.fetchall():
+            try:
+                row = self.db.execute(
+                    "SELECT fetched_at FROM weather_cache WHERE city_id=? ORDER BY fetched_at DESC LIMIT 1",
+                    (c["id"],),
+                ).fetchone()
+                now = datetime.utcnow()
+                last_success = datetime.fromisoformat(row["fetched_at"]) if row else datetime.min
+
+                attempts, last_attempt = self.failed_fetches.get(c["id"], (0, datetime.min))
+
+                if not force:
+                    if last_success > now - timedelta(hours=1):
+                        continue
+                    if attempts >= 3 and (now - last_attempt) < timedelta(hours=1):
+                        continue
+                    if attempts > 0 and (now - last_attempt) < timedelta(minutes=1):
+                        continue
+                    if attempts >= 3 and (now - last_attempt) >= timedelta(hours=1):
+                        attempts = 0
+
+                data = await self.fetch_open_meteo(c["lat"], c["lon"])
+                if not data or "current" not in data:
+                    self.failed_fetches[c["id"]] = (attempts + 1, now)
+                    continue
+
+                self.failed_fetches.pop(c["id"], None)
+                w = data["current"]
+                self.db.execute(
+                    "INSERT INTO weather_cache (city_id, fetched_at, provider, period, temp, wmo_code, wind) "
+                    "VALUES (?, ?, 'open-meteo', 'current', ?, ?, ?)",
+                    (
+                        c["id"],
+                        datetime.utcnow().isoformat(),
+                        w.get("temperature_2m"),
+                        w.get("weather_code"),
+                        w.get("wind_speed_10m"),
+                    ),
+                )
+                self.db.commit()
+                logging.info(
+                    "Cached weather for city %s: %s°C code %s",
+                    c["id"],
+                    w.get("temperature_2m"),
+                    w.get("weather_code"),
+                )
+            except Exception:
+                logging.exception("Error processing weather for city %s", c["id"])
 
     async def handle_update(self, update):
         if 'message' in update:
@@ -614,11 +708,34 @@ class Bot:
                 keyboard = {'inline_keyboard': [[{'text': 'Delete', 'callback_data': f'city_del:{r["id"]}'}]]}
                 await self.api_request('sendMessage', {
                     'chat_id': user_id,
-
                     'text': f"{r['id']}: {r['name']} ({r['lat']:.6f}, {r['lon']:.6f})",
-
                     'reply_markup': keyboard
                 })
+            return
+
+        if text.startswith('/weather') and self.is_superadmin(user_id):
+            parts = text.split(maxsplit=1)
+            if len(parts) > 1 and parts[1].lower() == 'now':
+                await self.collect_weather(force=True)
+            cur = self.db.execute('SELECT id, name FROM cities ORDER BY id')
+            rows = cur.fetchall()
+            if not rows:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'No cities'})
+                return
+            lines = []
+            for r in rows:
+                w = self.db.execute(
+                    'SELECT temp, wmo_code, wind, fetched_at FROM weather_cache WHERE city_id=? ORDER BY fetched_at DESC LIMIT 1',
+                    (r['id'],),
+                ).fetchone()
+                if w:
+                    emoji = WMO_EMOJI.get(w['wmo_code'], '')
+                    lines.append(
+                        f"{r['name']}: {w['temp']:.1f}°C {emoji} wind {w['wind']:.1f} m/s at {w['fetched_at']}"
+                    )
+                else:
+                    lines.append(f"{r['name']}: no data")
+            await self.api_request('sendMessage', {'chat_id': user_id, 'text': '\n'.join(lines)})
             return
 
         # handle time input for scheduling
@@ -833,6 +950,10 @@ class Bot:
             logging.info("Scheduler loop started")
             while self.running:
                 await self.process_due()
+                try:
+                    await self.collect_weather()
+                except Exception:
+                    logging.exception('Weather collection failed')
                 await asyncio.sleep(SCHED_INTERVAL_SEC)
         except asyncio.CancelledError:
             pass

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from datetime import datetime, timedelta
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -40,5 +41,116 @@ async def test_add_list_delete_city(tmp_path):
     cur = bot.db.execute("SELECT * FROM cities WHERE id=?", (cid,))
     assert cur.fetchone() is None
     assert any(c[0] == "editMessageReplyMarkup" for c in calls)
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_collect_and_report_weather(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    api_calls = []
+
+    async def dummy(method, data=None):
+        api_calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+
+    async def fetch_dummy(lat, lon):
+        return {"current": {"temperature_2m": 10.0, "weather_code": 1, "wind_speed_10m": 3.0}}
+
+    bot.fetch_open_meteo = fetch_dummy  # type: ignore
+
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'Paris', 48.85, 2.35)")
+    bot.db.commit()
+
+    await bot.collect_weather()
+
+    cur = bot.db.execute("SELECT temp, wmo_code FROM weather_cache WHERE city_id=1")
+    row = cur.fetchone()
+    assert row and row["temp"] == 10.0 and row["wmo_code"] == 1
+
+    await bot.handle_update({"message": {"text": "/weather", "from": {"id": 1}}})
+    assert api_calls[-1][0] == "sendMessage"
+    assert "Paris" in api_calls[-1][1]["text"]
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_weather_now_forces_fetch(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    api_calls = []
+    async def dummy(method, data=None):
+        api_calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+
+    count = 0
+    async def fetch_dummy(lat, lon):
+        nonlocal count
+        count += 1
+        return {"current": {"temperature_2m": 5.0, "weather_code": 2, "wind_speed_10m": 1.0}}
+
+    bot.fetch_open_meteo = fetch_dummy  # type: ignore
+
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'Rome', 41.9, 12.5)")
+    bot.db.commit()
+
+    await bot.handle_update({"message": {"text": "/weather now", "from": {"id": 1}}})
+    assert count == 1
+    assert api_calls[-1][0] == "sendMessage"
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_weather_retry_logic(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    count = 0
+    async def fetch_fail(lat, lon):
+        nonlocal count
+        count += 1
+        return None
+
+    bot.fetch_open_meteo = fetch_fail  # type: ignore
+
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'Rome', 41.9, 12.5)")
+    bot.db.commit()
+
+    await bot.collect_weather()
+    assert count == 1
+    # second call within a minute should not trigger another request
+    await bot.collect_weather()
+    assert count == 1
+
+    # pretend one minute passed
+    attempts, ts = bot.failed_fetches[1]
+    bot.failed_fetches[1] = (attempts, ts - timedelta(minutes=1, seconds=1))
+    await bot.collect_weather()
+    assert count == 2
+
+    # set three attempts in last second, should skip
+    bot.failed_fetches[1] = (3, datetime.utcnow())
+    await bot.collect_weather()
+    assert count == 2
+
+    # after an hour allowed again
+    bot.failed_fetches[1] = (3, datetime.utcnow() - timedelta(hours=1, minutes=1))
+    await bot.collect_weather()
+    assert count == 3
 
     await bot.close()


### PR DESCRIPTION
## Summary
- support forced weather updates via `/weather now`
- retry weather API failures up to three times with a 1‑minute pause
- document retry logic
- add tests for weather retries

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp>=3.9.5)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685d226be1108332a0db47efbf25bfa5