### PR TITLE
Implement weather now option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - Configurable scheduler interval.
 - Add inline buttons to existing posts.
 - Remove inline buttons from existing posts.
+- Hourly weather updates from Open-Meteo with the raw response logged. Admins
+  can view the latest data or force an update with `/weather now`.
 
 
 ## Commands
@@ -51,13 +53,13 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - **US-9**: `/delbutton <post_url>` removes inline buttons from an existing channel post.
 - **US-10**: Admin adds a city with `/addcity`.
 - **US-11**: Admin views and removes cities with `/cities`.
+- **US-12**: Periodic weather collection from Open-Meteo with up to three retries on failure.
+- **US-13**: Admin requests last weather check info and can force an update.
 
 ### In Progress
 - **US-7**: Logging of all operations.
 
 ### Planned
-- **US-12**: Periodic weather collection from Open-Meteo.
-- **US-13**: Admin requests last weather check info.
 - **US-14**: Admin registers a weather post for updates.
 - **US-15**: Automatic weather post updates.
 - **US-16**: Admin lists registered posts.

--- a/architectural_overview.md
+++ b/architectural_overview.md
@@ -13,7 +13,7 @@ The database is migrated via SQL files in the `migrations` folder.
 Handles Telegram updates and user commands.
 
 ### 3.2 WeatherService
-Collects current and forecast weather data from Open-Meteo for registered cities. It writes results to `weather_cache` and provides information for post templates.
+Collects current weather data from Open-Meteo for registered cities each hour using the request `https://api.open-meteo.com/v1/forecast?latitude=<lat>&longitude=<lon>&current=temperature_2m,weather_code,wind_speed_10m`. The raw response and parsed data are logged. Failed requests are retried up to three times with a minute pause, after which the service waits until the next hour. The bot ignores API errors so it continues running.
 
 ### 3.3 Webhook
 The HTTP server receives Telegram webhooks.
@@ -32,7 +32,7 @@ The application targets Fly.io free tier and runs a single process.
 - US-10: admin adds a city.
 - US-11: admin views and removes cities.
 - US-12: periodic weather collection from Open-Meteo.
-- US-13: admin requests last weather check info.
+- US-13: admin requests last weather check info and can force an update.
 - US-14: admin registers a weather post for updates.
 - US-15: automatic weather post updates.
 - US-16: admin lists registered posts.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -2,6 +2,18 @@
 
 This document describes the weather feature set for the Telegram scheduler bot.
 
+Weather for each city is queried from the Open-Meteo API approximately once per
+hour and stored in the `weather_cache` table. The bot logs both the raw HTTP
+response and the parsed weather information. The request looks like:
+
+```
+https://api.open-meteo.com/v1/forecast?latitude=<lat>&longitude=<lon>&current=temperature_2m,weather_code,wind_speed_10m
+```
+
+The bot continues working even if a query fails. When a request fails, it is
+retried up to three times with a one‑minute pause between attempts. After that,
+no further requests are made for that city until the next scheduled hour.
+
 
 ## Commands
 
@@ -11,6 +23,9 @@ This document describes the weather feature set for the Telegram scheduler bot.
 - `/cities` – list registered cities. Each entry has an inline *Delete* button that
   removes the city from the list. Coordinates are displayed with six decimal digits
   to reflect the stored precision.
+- `/weather` – show the last collected weather for all cities. Only superadmins may
+  request this information. Append `now` to force a fresh API request before
+  displaying results.
 
 
 ## Database schema

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from datetime import datetime, timedelta
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -40,5 +41,116 @@ async def test_add_list_delete_city(tmp_path):
     cur = bot.db.execute("SELECT * FROM cities WHERE id=?", (cid,))
     assert cur.fetchone() is None
     assert any(c[0] == "editMessageReplyMarkup" for c in calls)
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_collect_and_report_weather(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    api_calls = []
+
+    async def dummy(method, data=None):
+        api_calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+
+    async def fetch_dummy(lat, lon):
+        return {"current": {"temperature_2m": 10.0, "weather_code": 1, "wind_speed_10m": 3.0}}
+
+    bot.fetch_open_meteo = fetch_dummy  # type: ignore
+
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'Paris', 48.85, 2.35)")
+    bot.db.commit()
+
+    await bot.collect_weather()
+
+    cur = bot.db.execute("SELECT temp, wmo_code FROM weather_cache WHERE city_id=1")
+    row = cur.fetchone()
+    assert row and row["temp"] == 10.0 and row["wmo_code"] == 1
+
+    await bot.handle_update({"message": {"text": "/weather", "from": {"id": 1}}})
+    assert api_calls[-1][0] == "sendMessage"
+    assert "Paris" in api_calls[-1][1]["text"]
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_weather_now_forces_fetch(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    api_calls = []
+    async def dummy(method, data=None):
+        api_calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+
+    count = 0
+    async def fetch_dummy(lat, lon):
+        nonlocal count
+        count += 1
+        return {"current": {"temperature_2m": 5.0, "weather_code": 2, "wind_speed_10m": 1.0}}
+
+    bot.fetch_open_meteo = fetch_dummy  # type: ignore
+
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'Rome', 41.9, 12.5)")
+    bot.db.commit()
+
+    await bot.handle_update({"message": {"text": "/weather now", "from": {"id": 1}}})
+    assert count == 1
+    assert api_calls[-1][0] == "sendMessage"
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_weather_retry_logic(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    count = 0
+    async def fetch_fail(lat, lon):
+        nonlocal count
+        count += 1
+        return None
+
+    bot.fetch_open_meteo = fetch_fail  # type: ignore
+
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'Rome', 41.9, 12.5)")
+    bot.db.commit()
+
+    await bot.collect_weather()
+    assert count == 1
+    # second call within a minute should not trigger another request
+    await bot.collect_weather()
+    assert count == 1
+
+    # pretend one minute passed
+    attempts, ts = bot.failed_fetches[1]
+    bot.failed_fetches[1] = (attempts, ts - timedelta(minutes=1, seconds=1))
+    await bot.collect_weather()
+    assert count == 2
+
+    # set three attempts in last second, should skip
+    bot.failed_fetches[1] = (3, datetime.utcnow())
+    await bot.collect_weather()
+    assert count == 2
+
+    # after an hour allowed again
+    bot.failed_fetches[1] = (3, datetime.utcnow() - timedelta(hours=1, minutes=1))
+    await bot.collect_weather()
+    assert count == 3
 
     await bot.close()


### PR DESCRIPTION
## Summary
- support forced weather updates via `/weather now`
- retry weather API failures up to three times with a 1‑minute pause
- log raw weather provider responses
- document retry logic and request format
- add tests for weather retries

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp>=3.9.5)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_685d226be1108332a0db47efbf25bfa5