### PR TITLE
Add sea temperature support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - Weather updates from Open-Meteo roughly every 30 minutes with the raw response logged. Admins
   can view the latest data or force an update with `/weather now`.
 - Register channel posts with custom templates for automatic weather updates,
-  working with both text and caption posts.
+  including sea temperature, working with both text and caption posts.
 
 
 ## Commands
@@ -34,7 +34,9 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - /delbutton <post_url> - remove all buttons from an existing post
 
 - /addcity <name> <lat> <lon> - add a city for weather checks (admin, coordinates
-  may include six or more decimal places)
+  may include six or more decimal places and may be separated with a comma)
+- /addsea <name> <lat> <lon> - add a sea location for water temperature checks
+  (comma separator allowed)
 - /cities - list cities with inline delete buttons (admin). Coordinates are shown
   with six decimal places.
 
@@ -57,9 +59,9 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - **US-11**: Admin views and removes cities with `/cities`.
 - **US-12**: Periodic weather collection from Open-Meteo with up to three retries on failure.
 - **US-13**: Admin requests last weather check info and can force an update.
-- **US-14**: Admin registers a weather post for updates.
-- **US-15**: Automatic weather post updates.
-- **US-16**: Admin lists registered posts.
+- **US-14**: Admin registers a weather post for updates, including sea temperature.
+- **US-15**: Automatic weather post updates with current weather and sea temperature.
+- **US-16**: Admin lists registered posts showing the rendered weather and sea data.
 
 
 

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -20,10 +20,13 @@ no further requests are made for that city until the next scheduled half hour.
 
 - `/addcity <name> <lat> <lon>` – add a city to the database. Only superadmins can
   execute this command. Latitude and longitude must be valid floating point numbers
-  and may include six or more digits after the decimal point.
+  and may include six or more digits after the decimal point. Coordinates may be
+  separated with a comma.
 - `/cities` – list registered cities. Each entry has an inline *Delete* button that
   removes the city from the list. Coordinates are displayed with six decimal digits
   to reflect the stored precision.
+- `/addsea <name> <lat> <lon>` – add a sea location for water temperature checks.
+  Coordinates may also be separated with a comma.
 - `/weather` – show the last collected weather for all cities. Only superadmins may
 
   request this information. Append `now` to force a fresh API request before
@@ -31,8 +34,8 @@ no further requests are made for that city until the next scheduled half hour.
 - `/regweather <post_url> <template>` – register a channel post for automatic
   weather updates. The template may include placeholders like
 
-  `{<city_id>|temperature}` or `{<city_id>|wind}` mixed with text. Sea
-  temperature will be available later as `{<city_id>|seatemperature}`. If the
+  `{<city_id>|temperature}` or `{<city_id>|wind}` mixed with text. Water
+  temperature can be inserted with `{<sea_id>|seatemperature}`. If the
   message already contains a weather header separated by `∙` it will be stripped
   when registering so only the original text remains.
 
@@ -95,6 +98,24 @@ CREATE TABLE IF NOT EXISTS weather_posts (
     reply_markup TEXT,
 
     UNIQUE(chat_id, message_id)
+);
+
+CREATE TABLE IF NOT EXISTS seas (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    lat REAL NOT NULL,
+    lon REAL NOT NULL,
+    UNIQUE(name)
+);
+
+CREATE TABLE IF NOT EXISTS sea_cache (
+    sea_id INTEGER PRIMARY KEY,
+    updated TEXT,
+    current REAL,
+    morning REAL,
+    day REAL,
+    evening REAL,
+    night REAL
 );
 ```
 

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ CREATE_TABLES = [
             wind_speed REAL,
             PRIMARY KEY (city_id, day)
         )""",
-    """CREATE TABLE IF NOT EXISTS weather_cache_hour (
+        """CREATE TABLE IF NOT EXISTS weather_cache_hour (
             city_id INTEGER NOT NULL,
             timestamp DATETIME NOT NULL,
             temperature REAL,
@@ -110,6 +110,24 @@ CREATE_TABLES = [
             wind_speed REAL,
             is_day INTEGER,
             PRIMARY KEY (city_id, timestamp)
+        )""",
+
+    """CREATE TABLE IF NOT EXISTS seas (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            lat REAL NOT NULL,
+            lon REAL NOT NULL,
+            UNIQUE(name)
+        )""",
+
+    """CREATE TABLE IF NOT EXISTS sea_cache (
+            sea_id INTEGER PRIMARY KEY,
+            updated TEXT,
+            current REAL,
+            morning REAL,
+            day REAL,
+            evening REAL,
+            night REAL
         )""",
 
     """CREATE TABLE IF NOT EXISTS weather_posts (
@@ -146,6 +164,12 @@ class Bot:
 
             ("weather_posts", "base_caption"),
             ("weather_posts", "reply_markup"),
+            ("sea_cache", "updated"),
+            ("sea_cache", "current"),
+            ("sea_cache", "morning"),
+            ("sea_cache", "day"),
+            ("sea_cache", "evening"),
+            ("sea_cache", "night"),
 
         ):
             cur = self.db.execute(f"PRAGMA table_info({table})")
@@ -221,6 +245,29 @@ class Bot:
         logging.info("Weather response: %s", data.get("current"))
         return data
 
+    async def fetch_open_meteo_sea(self, lat: float, lon: float) -> dict | None:
+        url = (
+            "https://marine-api.open-meteo.com/v1/marine?latitude="
+            f"{lat}&longitude={lon}&hourly=water_temperature&timezone=auto"
+        )
+        try:
+            async with self.session.get(url) as resp:
+                text = await resp.text()
+        except Exception:
+            logging.exception("Failed to fetch sea")
+            return None
+
+        logging.info("Sea API raw response: %s", text)
+        if resp.status != 200:
+            logging.error("Open-Meteo sea HTTP %s", resp.status)
+            return None
+        try:
+            data = json.loads(text)
+        except Exception:
+            logging.exception("Invalid sea JSON")
+            return None
+        return data
+
     async def collect_weather(self, force: bool = False):
 
         cur = self.db.execute("SELECT id, lat, lon, name FROM cities")
@@ -294,6 +341,62 @@ class Bot:
                 logging.exception("Error processing weather for city %s", c["id"])
         if updated:
             await self.update_weather_posts(updated)
+
+    async def collect_sea(self, force: bool = False):
+        cur = self.db.execute("SELECT id, lat, lon FROM seas")
+        updated: set[int] = set()
+        for s in cur.fetchall():
+            row = self.db.execute(
+                "SELECT updated FROM sea_cache WHERE sea_id=?",
+                (s["id"],),
+            ).fetchone()
+            now = datetime.utcnow()
+            last = datetime.fromisoformat(row["updated"]) if row else datetime.min
+            if not force and last > now - timedelta(minutes=30):
+                continue
+
+            data = await self.fetch_open_meteo_sea(s["lat"], s["lon"])
+            if not data or "hourly" not in data:
+                continue
+            temps = data["hourly"].get("water_temperature") or data["hourly"].get("sea_surface_temperature")
+            times = data["hourly"].get("time")
+            if not temps or not times:
+                continue
+
+            current = temps[0]
+            tomorrow = date.today() + timedelta(days=1)
+            morn = day_temp = eve = night = None
+            for t, temp in zip(times, temps):
+                dt = datetime.fromisoformat(t)
+                if dt.date() != tomorrow:
+                    continue
+                if dt.hour == 6 and morn is None:
+                    morn = temp
+                elif dt.hour == 12 and day_temp is None:
+                    day_temp = temp
+                elif dt.hour == 18 and eve is None:
+                    eve = temp
+                elif dt.hour == 0 and night is None:
+                    night = temp
+                if morn is not None and day_temp is not None and eve is not None and night is not None:
+                    break
+
+            self.db.execute(
+                "INSERT OR REPLACE INTO sea_cache (sea_id, updated, current, morning, day, evening, night) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    s["id"],
+                    now.isoformat(),
+                    current,
+                    morn,
+                    day_temp,
+                    eve,
+                    night,
+                ),
+            )
+            self.db.commit()
+            updated.add(s["id"])
+        if updated:
+            await self.update_weather_posts()
 
     async def handle_update(self, update):
         if 'message' in update:
@@ -444,12 +547,39 @@ class Bot:
             (city_id,),
         ).fetchone()
 
+    def _get_sea_cache(self, sea_id: int):
+        return self.db.execute(
+            "SELECT current, morning, day, evening, night FROM sea_cache WHERE sea_id=?",
+            (sea_id,),
+        ).fetchone()
+
+    @staticmethod
+    def _parse_coords(text: str) -> tuple[float, float] | None:
+        """Parse latitude and longitude from string allowing comma separator."""
+        parts = [p for p in re.split(r"[ ,]+", text.strip()) if p]
+        if len(parts) != 2:
+            return None
+        try:
+            return float(parts[0]), float(parts[1])
+        except ValueError:
+            return None
+
     def _render_template(self, template: str) -> str | None:
         """Replace placeholders in template with cached weather values."""
 
         def repl(match: re.Match[str]) -> str:
             cid = int(match.group(1))
             field = match.group(2)
+            if field == "seatemperature":
+                row = self._get_sea_cache(cid)
+                if not row:
+                    raise ValueError(f"no sea data for {cid}")
+                emoji = "\U0001F30A"
+                return (
+                    f"{emoji} {row['current']:.1f}\u00B0C "
+                    f"{row['morning']:.1f}/{row['day']:.1f}/{row['evening']:.1f}/{row['night']:.1f}"
+                )
+
             row = self._get_cached_weather(cid)
             if not row:
                 raise ValueError(f"no data for city {cid}")
@@ -461,13 +591,6 @@ class Bot:
                 return f"{emoji} {row['temperature']:.1f}\u00B0C"
             if field == "wind":
                 return f"{row['wind_speed']:.1f}"
-            if field == "seatemperature":
-
-                sea = row["sea_temperature"] if "sea_temperature" in row.keys() else None
-
-                if sea is None:
-                    raise ValueError("no sea temperature")
-                return f"{sea:.1f}\u00B0C"
             return ""
 
         try:
@@ -859,15 +982,14 @@ class Bot:
             return
 
         if text.startswith('/addcity') and self.is_superadmin(user_id):
-            parts = text.split()
-            if len(parts) == 4:
+            parts = text.split(maxsplit=2)
+            if len(parts) == 3:
                 name = parts[1]
-                try:
-                    lat = float(parts[2])
-                    lon = float(parts[3])
-                except ValueError:
+                coords = self._parse_coords(parts[2])
+                if not coords:
                     await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Invalid coordinates'})
                     return
+                lat, lon = coords
                 try:
                     self.db.execute('INSERT INTO cities (name, lat, lon) VALUES (?, ?, ?)', (name, lat, lon))
                     self.db.commit()
@@ -876,6 +998,25 @@ class Bot:
                     await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'City already exists'})
             else:
                 await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Usage: /addcity <name> <lat> <lon>'})
+            return
+
+        if text.startswith('/addsea') and self.is_superadmin(user_id):
+            parts = text.split(maxsplit=2)
+            if len(parts) == 3:
+                name = parts[1]
+                coords = self._parse_coords(parts[2])
+                if not coords:
+                    await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Invalid coordinates'})
+                    return
+                lat, lon = coords
+                try:
+                    self.db.execute('INSERT INTO seas (name, lat, lon) VALUES (?, ?, ?)', (name, lat, lon))
+                    self.db.commit()
+                    await self.api_request('sendMessage', {'chat_id': user_id, 'text': f'Sea {name} added'})
+                except sqlite3.IntegrityError:
+                    await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Sea already exists'})
+            else:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Usage: /addsea <name> <lat> <lon>'})
             return
 
         if text.startswith('/cities') and self.is_superadmin(user_id):
@@ -1208,6 +1349,7 @@ class Bot:
                 await self.process_due()
                 try:
                     await self.collect_weather()
+                    await self.collect_sea()
                 except Exception:
                     logging.exception('Weather collection failed')
                 await asyncio.sleep(SCHED_INTERVAL_SEC)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -373,6 +373,69 @@ async def test_night_clear_emoji(tmp_path):
     # last sendMessage should include moon emoji U+1F319
     assert "\U0001F319" in api_calls[-1][1]["text"]
 
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_add_sea_and_template(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    api_calls = []
+
+    async def dummy(method, data=None):
+        api_calls.append((method, data))
+        if method == "forwardMessage":
+            return {"ok": True, "result": {"message_id": 99, "text": "orig"}}
+        return {"ok": True, "result": {"message_id": 1}}
+
+    bot.api_request = dummy  # type: ignore
+
+    async def fetch_sea(lat, lon):
+        tomorrow = date.today() + timedelta(days=1)
+        times = [
+            datetime.utcnow().isoformat(),
+            datetime.combine(tomorrow, datetime.min.time()).isoformat(),
+            datetime.combine(tomorrow, datetime.min.time().replace(hour=6)).isoformat(),
+            datetime.combine(tomorrow, datetime.min.time().replace(hour=12)).isoformat(),
+            datetime.combine(tomorrow, datetime.min.time().replace(hour=18)).isoformat(),
+        ]
+        temps = [19.0, 20.0, 21.0, 22.0, 23.0]
+        return {"hourly": {"water_temperature": temps, "time": times}}
+
+    bot.fetch_open_meteo_sea = fetch_sea  # type: ignore
+
+    await bot.start()
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    await bot.handle_update({"message": {"text": "/addsea Black 40 30", "from": {"id": 1}}})
+    cur = bot.db.execute("SELECT name FROM seas")
+    assert cur.fetchone()["name"] == "Black"
+
+    await bot.handle_update({"message": {"text": "/regweather https://t.me/c/1/1 {1|seatemperature}", "from": {"id": 1}}})
+    await bot.collect_sea()
+    assert any(c[0] == "editMessageText" for c in api_calls)
+    text = [c[1]["text"] for c in api_calls if c[0] == "editMessageText"][0]
+    assert "\U0001F30A" in text
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_add_sea_comma_coords(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    async def dummy(method, data=None):
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+
+    await bot.start()
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    await bot.handle_update({"message": {"text": "/addsea Baltic 54.1, 19.2", "from": {"id": 1}}})
+
+    cur = bot.db.execute("SELECT lat, lon FROM seas WHERE name='Baltic'")
+    row = cur.fetchone()
+    assert round(row["lat"], 1) == 54.1 and round(row["lon"], 1) == 19.2
 
     await bot.close()
 


### PR DESCRIPTION
## Summary
- support sea temperature caching and template rendering
- add `/addsea` command
- track and cache sea temperature for posts
- update docs and README
- add tests for sea temperature features
- allow comma-separated coordinates for `/addcity` and `/addsea`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685f193996208332ac55f617f0a9f692