### PR TITLE
Add weather button updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - /seas - list sea locations with inline delete buttons (admin).
 - /weather [now] - show cached weather; append `now` to refresh data
 - /regweather <post_url> <template> - register a post for weather updates
+- /addweatherbutton <post_url> <text> [url] - attach a button linking to the latest forecast. Text supports the same placeholders as templates
 - /weatherposts [update] - list registered weather posts; append `update` to refresh
 - /setup_weather - interactive wizard to add a daily forecast channel
 - /list_weather_channels - show configured weather channels with action buttons
@@ -88,12 +89,14 @@ contains only fresh assets.
 - **US-5**: Post scheduling interface with channel selection, cancellation and rescheduling. Scheduled list shows the post preview or link along with the target channel name and time in HH:MM DD.MM.YYYY format.
 - **US-6**: Scheduler forwards queued posts at the correct local time. If forwarding fails because the bot is not a member, it falls back to copying. Interval is configurable and all actions are logged.
 - **US-8**: `/addbutton <post_url> <text> <url>` adds an inline button to an existing channel post. Update logged with INFO level.
-- **US-9**: `/delbutton <post_url>` removes inline buttons from an existing channel post.
+- **US-8.1**: `/addbutton` appends a new button without removing existing ones.
+- **US-9**: `/delbutton <post_url>` removes all inline buttons from an existing channel post.
 - **US-10**: Admin adds a city with `/addcity`.
 - **US-11**: Admin views and removes cities with `/cities`.
 - **US-12**: Periodic weather collection from Open-Meteo with up to three retries on failure.
 - **US-13**: Admin requests last weather check info and can force an update.
 - **US-14**: Admin registers a weather post for updates, including sea temperature.
+- **US-14.1**: `/addweatherbutton <post_url> <text> [url]` attaches a button linking to the latest `#котопогода`. `/weatherposts` lists these posts with a remove option.
 - **US-15**: Automatic weather post updates with current weather and sea temperature.
 - **US-16**: Admin lists registered posts showing the rendered weather and sea data for all registered seas.
 - **US-17**: Admin adds a channel for daily weather posts and specifies the publication time with `/setup_weather`.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -50,6 +50,7 @@ no further requests are made for that city until the next scheduled half hour.
 
   message already contains a weather header separated by `∙` it will be stripped
   when registering so only the original text remains.
+- `/addweatherbutton <post_url> <text> [url]` – add a button linking to the latest forecast. Button text supports the same placeholders as templates. Provide the URL manually if no forecast exists yet.
 
 - `/weatherposts` – list registered weather posts. Append `update` to refresh all
   posts immediately. Each entry shows the post link followed by the rendered

--- a/main.py
+++ b/main.py
@@ -151,7 +151,7 @@ CREATE_TABLES = [
         )""",
 
 
-    """CREATE TABLE IF NOT EXISTS weather_cache_period (
+        """CREATE TABLE IF NOT EXISTS weather_cache_period (
             city_id INTEGER PRIMARY KEY,
             updated TEXT,
             morning_temp REAL,
@@ -166,6 +166,20 @@ CREATE_TABLES = [
             night_temp REAL,
             night_code INTEGER,
             night_wind REAL
+        )""",
+
+    """CREATE TABLE IF NOT EXISTS latest_weather_post (
+            chat_id BIGINT,
+            message_id BIGINT,
+            published_at TEXT
+        )""",
+
+    """CREATE TABLE IF NOT EXISTS weather_link_posts (
+            chat_id BIGINT NOT NULL,
+            message_id BIGINT NOT NULL,
+            base_markup TEXT,
+            button_texts TEXT,
+            UNIQUE(chat_id, message_id)
         )""",
 
 ]
@@ -834,6 +848,45 @@ class Bot:
                     "Failed to update weather post %s: %s", r["id"], resp
                 )
 
+    def latest_weather_url(self) -> str | None:
+        cur = self.db.execute(
+            "SELECT chat_id, message_id FROM latest_weather_post LIMIT 1"
+        )
+        row = cur.fetchone()
+        if row:
+            return self.post_url(row["chat_id"], row["message_id"])
+        return None
+
+    def set_latest_weather_post(self, chat_id: int, message_id: int):
+        self.db.execute("DELETE FROM latest_weather_post")
+        self.db.execute(
+            "INSERT INTO latest_weather_post (chat_id, message_id, published_at) VALUES (?, ?, ?)",
+            (chat_id, message_id, datetime.utcnow().isoformat()),
+        )
+        self.db.commit()
+
+    async def update_weather_buttons(self):
+        url = self.latest_weather_url()
+        if not url:
+            return
+        cur = self.db.execute(
+            "SELECT chat_id, message_id, base_markup, button_texts FROM weather_link_posts"
+        )
+        for r in cur.fetchall():
+            base = json.loads(r["base_markup"]) if r["base_markup"] else {"inline_keyboard": []}
+            buttons = base.get("inline_keyboard", [])
+            for t in json.loads(r["button_texts"]):
+                rendered = self._render_template(t) or t
+                buttons.append([{"text": rendered, "url": url}])
+            await self.api_request(
+                "editMessageReplyMarkup",
+                {
+                    "chat_id": r["chat_id"],
+                    "message_id": r["message_id"],
+                    "reply_markup": {"inline_keyboard": buttons},
+                },
+            )
+
     def add_weather_channel(self, channel_id: int, post_time: str):
         self.db.execute(
             "INSERT OR REPLACE INTO weather_publish_channels (channel_id, post_time) VALUES (?, ?)",
@@ -988,12 +1041,16 @@ class Bot:
             return False
 
         if ok and record:
-
             self.db.execute(
                 "UPDATE weather_publish_channels SET last_published_at=? WHERE channel_id=?",
                 (datetime.utcnow().isoformat(), channel_id),
             )
             self.db.commit()
+            if resp.get("result"):
+                mid = resp["result"].get("message_id")
+                if mid:
+                    self.set_latest_weather_post(channel_id, mid)
+                    await self.update_weather_buttons()
         else:
             logging.error("Failed to publish weather: %s", resp)
         return ok
@@ -1273,7 +1330,6 @@ class Bot:
 
             parts = text.split()
             if len(parts) < 4:
-
                 await self.api_request('sendMessage', {
                     'chat_id': user_id,
                     'text': 'Usage: /addbutton <post_url> <text> <url>'
@@ -1284,9 +1340,19 @@ class Bot:
                 await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Invalid post URL'})
                 return
             chat_id, msg_id = parsed
-
             keyboard_text = " ".join(parts[2:-1])
-            keyboard = {'inline_keyboard': [[{'text': keyboard_text, 'url': parts[-1]}]]}
+            fwd = await self.api_request('forwardMessage', {
+                'chat_id': user_id,
+                'from_chat_id': chat_id,
+                'message_id': msg_id
+            })
+            markup = None
+            if fwd.get('ok'):
+                markup = fwd['result'].get('reply_markup')
+                await self.api_request('deleteMessage', {'chat_id': user_id, 'message_id': fwd['result']['message_id']})
+            buttons = markup.get('inline_keyboard', []) if markup else []
+            buttons.append([{'text': keyboard_text, 'url': parts[-1]}])
+            keyboard = {'inline_keyboard': buttons}
 
             resp = await self.api_request('editMessageReplyMarkup', {
                 'chat_id': chat_id,
@@ -1330,6 +1396,81 @@ class Bot:
             else:
                 logging.error('Failed to remove button from %s: %s', msg_id, resp)
                 await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Failed to remove button'})
+            return
+
+        if text.startswith('/addweatherbutton') and self.is_superadmin(user_id):
+            parts = text.split()
+            if len(parts) < 3:
+                await self.api_request(
+                    'sendMessage',
+                    {
+                        'chat_id': user_id,
+                        'text': 'Usage: /addweatherbutton <post_url> <text> [url]'
+                    },
+                )
+                return
+
+            url = None
+            if len(parts) > 3:
+                url = parts[-1]
+                btn_text = " ".join(parts[2:-1])
+            else:
+                btn_text = " ".join(parts[2:])
+                url = self.latest_weather_url()
+                if not url:
+                    await self.api_request(
+                        'sendMessage',
+                        {
+                            'chat_id': user_id,
+                            'text': 'Specify forecast URL after text'
+                        },
+                    )
+                    return
+
+            parsed = await self.parse_post_url(parts[1])
+            if not parsed:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Invalid post URL'})
+                return
+            chat_id, msg_id = parsed
+            fwd = await self.api_request(
+                'forwardMessage',
+                {'chat_id': user_id, 'from_chat_id': chat_id, 'message_id': msg_id},
+            )
+            markup = None
+            if fwd.get('ok'):
+                markup = fwd['result'].get('reply_markup')
+                await self.api_request('deleteMessage', {'chat_id': user_id, 'message_id': fwd['result']['message_id']})
+
+            row = self.db.execute(
+                'SELECT base_markup, button_texts FROM weather_link_posts WHERE chat_id=? AND message_id=?',
+                (chat_id, msg_id),
+            ).fetchone()
+            base_markup = row['base_markup'] if row else json.dumps(markup) if markup else None
+            texts = json.loads(row['button_texts']) if row else []
+            if row is None:
+                base_buttons = markup.get('inline_keyboard', []) if markup else []
+            else:
+                base_buttons = json.loads(base_markup)['inline_keyboard'] if base_markup else []
+            texts.append(btn_text)
+            rendered_texts = [self._render_template(t) or t for t in texts]
+            keyboard_buttons = base_buttons + [[{'text': t, 'url': url}] for t in rendered_texts]
+            resp = await self.api_request(
+                'editMessageReplyMarkup',
+                {
+                    'chat_id': chat_id,
+                    'message_id': msg_id,
+                    'reply_markup': {'inline_keyboard': keyboard_buttons},
+                },
+            )
+            if resp.get('ok'):
+                self.db.execute(
+                    'INSERT OR REPLACE INTO weather_link_posts (chat_id, message_id, base_markup, button_texts) VALUES (?, ?, ?, ?)',
+                    (chat_id, msg_id, base_markup, json.dumps(texts)),
+                )
+                self.db.commit()
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Weather button added'})
+            else:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Failed to add weather button'})
             return
 
         if text.startswith('/addcity') and self.is_superadmin(user_id):
@@ -1407,22 +1548,38 @@ class Bot:
             force = len(parts) > 1 and parts[1] == 'update'
             if force:
                 await self.update_weather_posts()
+                await self.update_weather_buttons()
             cur = self.db.execute(
                 'SELECT chat_id, message_id, template FROM weather_posts ORDER BY id'
             )
             rows = cur.fetchall()
-            if not rows:
+            if rows:
+                lines = []
+                for r in rows:
+                    header = self._render_template(r['template'])
+                    url = self.post_url(r['chat_id'], r['message_id'])
+                    if header:
+                        lines.append(f"{url} {header}")
+                    else:
+                        lines.append(f"{url} no data")
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': '\n'.join(lines)})
+            cur = self.db.execute('SELECT chat_id, message_id, button_texts FROM weather_link_posts ORDER BY rowid')
+            rows = cur.fetchall()
+            if not rows and not lines:
                 await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'No weather posts'})
                 return
-            lines = []
             for r in rows:
-                header = self._render_template(r['template'])
-                url = self.post_url(r['chat_id'], r['message_id'])
-                if header:
-                    lines.append(f"{url} {header}")
-                else:
-                    lines.append(f"{url} no data")
-            await self.api_request('sendMessage', {'chat_id': user_id, 'text': '\n'.join(lines)})
+                rendered = [self._render_template(t) or t for t in json.loads(r['button_texts'])]
+                texts = ', '.join(rendered)
+                keyboard = {'inline_keyboard': [[{'text': 'Remove buttons', 'callback_data': f'wbtn_del:{r["chat_id"]}:{r["message_id"]}'}]]}
+                await self.api_request(
+                    'sendMessage',
+                    {
+                        'chat_id': user_id,
+                        'text': f"{self.post_url(r['chat_id'], r['message_id'])} buttons: {texts}",
+                        'reply_markup': keyboard,
+                    },
+                )
             return
 
         if text.startswith('/setup_weather') and self.is_superadmin(user_id):
@@ -1725,6 +1882,29 @@ class Bot:
             cid = int(data.split(':')[1])
             self.remove_weather_channel(cid)
             await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Channel removed'})
+        elif data.startswith('wbtn_del:') and self.is_superadmin(user_id):
+            _, cid, mid = data.split(':')
+            chat_id = int(cid)
+            msg_id = int(mid)
+            row = self.db.execute(
+                'SELECT base_markup FROM weather_link_posts WHERE chat_id=? AND message_id=?',
+                (chat_id, msg_id),
+            ).fetchone()
+            markup = json.loads(row['base_markup']) if row and row['base_markup'] else {}
+            await self.api_request(
+                'editMessageReplyMarkup',
+                {
+                    'chat_id': chat_id,
+                    'message_id': msg_id,
+                    'reply_markup': markup,
+                },
+            )
+            self.db.execute(
+                'DELETE FROM weather_link_posts WHERE chat_id=? AND message_id=?',
+                (chat_id, msg_id),
+            )
+            self.db.commit()
+            await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Weather buttons removed'})
         elif data.startswith('approve:') and self.is_superadmin(user_id):
             uid = int(data.split(':')[1])
             if self.approve_user(uid):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -297,10 +297,35 @@ async def test_add_button(tmp_path):
 
     calls = []
 
+    forward_resps = [
+        {
+            "ok": True,
+            "result": {
+                "message_id": 42,
+                "reply_markup": {"inline_keyboard": [[{"text": "old", "url": "u"}]]},
+            },
+        },
+        {
+            "ok": True,
+            "result": {
+                "message_id": 42,
+                "reply_markup": {
+                    "inline_keyboard": [[{"text": "old", "url": "u"}, {"text": "btn", "url": "https://example.com"}]]
+                },
+            },
+        },
+    ]
+    count = 0
+
     async def dummy(method, data=None):
+        nonlocal count
         calls.append((method, data))
         if method == "getChat":
             return {"ok": True, "result": {"id": -100123}}
+        if method == "forwardMessage":
+            resp = forward_resps[count]
+            count += 1
+            return resp
         return {"ok": True}
 
     bot.api_request = dummy  # type: ignore
@@ -314,9 +339,9 @@ async def test_add_button(tmp_path):
             "from": {"id": 1},
         }
     })
-
-    assert any(c[0] == "editMessageReplyMarkup" for c in calls)
-
+    edit_calls = [c for c in calls if c[0] == "editMessageReplyMarkup"]
+    assert len(edit_calls) == 1
+    assert len(edit_calls[0][1]["reply_markup"]["inline_keyboard"]) == 2
 
     await bot.handle_update({
         "message": {
@@ -329,7 +354,8 @@ async def test_add_button(tmp_path):
     edit_calls = [c for c in calls if c[0] == "editMessageReplyMarkup"]
     assert len(edit_calls) == 2
     payload = edit_calls[-1][1]
-    assert payload["reply_markup"]["inline_keyboard"][0][0]["text"] == "ask locals"
+    assert len(payload["reply_markup"]["inline_keyboard"]) == 3
+    assert payload["reply_markup"]["inline_keyboard"][2][0]["text"] == "ask locals"
 
     await bot.close()
 
@@ -358,5 +384,52 @@ async def test_delete_button(tmp_path):
 
     assert calls[-1][0] == "editMessageReplyMarkup"
     assert calls[-1][1]["reply_markup"] == {}
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_add_weather_button(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        if method == "forwardMessage":
+            return {
+                "ok": True,
+                "result": {"message_id": 11, "reply_markup": {"inline_keyboard": []}},
+            }
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    bot.set_latest_weather_post(-100, 7)
+    await bot.start()
+
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'c', 0, 0)")
+    bot.db.execute(
+        "INSERT INTO weather_cache_hour (city_id, timestamp, temperature, weather_code, wind_speed, is_day) VALUES (1, ?, 15.0, 1, 3, 1)",
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    await bot.handle_update({
+        "message": {
+            "text": "/addweatherbutton https://t.me/c/123/5 K. {1|temperature}",
+            "from": {"id": 1},
+        }
+    })
+
+    assert any(c[0] == "editMessageReplyMarkup" for c in calls)
+    payload = [c[1] for c in calls if c[0] == "editMessageReplyMarkup"][0]
+    assert payload["reply_markup"]["inline_keyboard"][0][0]["url"].endswith("/7")
+    assert "\u00B0C" in payload["reply_markup"]["inline_keyboard"][0][0]["text"]
+
+    calls.clear()
+    await bot.update_weather_buttons()
+    up_payload = [c[1] for c in calls if c[0] == "editMessageReplyMarkup"][0]
+    assert "\u00B0C" in up_payload["reply_markup"]["inline_keyboard"][0][0]["text"]
 
     await bot.close()


### PR DESCRIPTION
## Summary
- keep previous buttons when calling `/addbutton`
- remove all buttons with `/delbutton`
- track the latest weather post and update inline weather buttons via `/addweatherbutton`
- show weather button posts in `/weatherposts`
- document new US-8.1 and US-14.1 features
- test improvements
- fix rendering for weather button templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68618bdd05a0833296a41c6e2d67d4c1