### PR TITLE
Add weather button updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - /history - recent posts
 - /tz <offset> - set timezone offset (e.g., +02:00). Affects daily weather schedules immediately
 - /addbutton <post_url> <text> <url> - add inline button to existing post (button text may contain spaces)
-- /delbutton <post_url> - remove all buttons from an existing post
+- /delbutton <post_url> - remove all buttons from an existing post and clear stored weather buttons
 
 - /addcity <name> <lat> <lon> - add a city for weather checks (admin, coordinates
 
@@ -51,6 +51,7 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 - /seas - list sea locations with inline delete buttons (admin).
 - /weather [now] - show cached weather; append `now` to refresh data
 - /regweather <post_url> <template> - register a post for weather updates
+ - /addweatherbutton <post_url> <text> [url] - attach a button linking to the latest forecast. Text supports the same placeholders as templates. Multiple weather buttons share one row
 - /weatherposts [update] - list registered weather posts; append `update` to refresh
 - /setup_weather - interactive wizard to add a daily forecast channel
 - /list_weather_channels - show configured weather channels with action buttons
@@ -88,12 +89,14 @@ contains only fresh assets.
 - **US-5**: Post scheduling interface with channel selection, cancellation and rescheduling. Scheduled list shows the post preview or link along with the target channel name and time in HH:MM DD.MM.YYYY format.
 - **US-6**: Scheduler forwards queued posts at the correct local time. If forwarding fails because the bot is not a member, it falls back to copying. Interval is configurable and all actions are logged.
 - **US-8**: `/addbutton <post_url> <text> <url>` adds an inline button to an existing channel post. Update logged with INFO level.
-- **US-9**: `/delbutton <post_url>` removes inline buttons from an existing channel post.
+- **US-8.1**: `/addbutton` appends a new button without removing existing ones.
+- **US-9**: `/delbutton <post_url>` removes all inline buttons from an existing channel post and deletes stored weather button data.
 - **US-10**: Admin adds a city with `/addcity`.
 - **US-11**: Admin views and removes cities with `/cities`.
 - **US-12**: Periodic weather collection from Open-Meteo with up to three retries on failure.
 - **US-13**: Admin requests last weather check info and can force an update.
 - **US-14**: Admin registers a weather post for updates, including sea temperature.
+ - **US-14.1**: `/addweatherbutton <post_url> <text> [url]` attaches a button linking to the latest `#котопогода`. Multiple weather buttons are placed on one row. `/weatherposts` lists these posts with a remove option.
 - **US-15**: Automatic weather post updates with current weather and sea temperature.
 - **US-16**: Admin lists registered posts showing the rendered weather and sea data for all registered seas.
 - **US-17**: Admin adds a channel for daily weather posts and specifies the publication time with `/setup_weather`.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -50,6 +50,8 @@ no further requests are made for that city until the next scheduled half hour.
 
   message already contains a weather header separated by `∙` it will be stripped
   when registering so only the original text remains.
+ - `/addweatherbutton <post_url> <text> [url]` – add a button linking to the latest forecast. Button text supports the same placeholders as templates. Provide the URL manually if no forecast exists yet. Multiple weather buttons appear on the same row.
+- `/delbutton <post_url>` – remove all buttons from a post and delete any stored weather button data so they do not reappear.
 
 - `/weatherposts` – list registered weather posts. Append `update` to refresh all
   posts immediately. Each entry shows the post link followed by the rendered

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -297,10 +297,35 @@ async def test_add_button(tmp_path):
 
     calls = []
 
+    forward_resps = [
+        {
+            "ok": True,
+            "result": {
+                "message_id": 42,
+                "reply_markup": {"inline_keyboard": [[{"text": "old", "url": "u"}]]},
+            },
+        },
+        {
+            "ok": True,
+            "result": {
+                "message_id": 42,
+                "reply_markup": {
+                    "inline_keyboard": [[{"text": "old", "url": "u"}, {"text": "btn", "url": "https://example.com"}]]
+                },
+            },
+        },
+    ]
+    count = 0
+
     async def dummy(method, data=None):
+        nonlocal count
         calls.append((method, data))
         if method == "getChat":
             return {"ok": True, "result": {"id": -100123}}
+        if method == "forwardMessage":
+            resp = forward_resps[count]
+            count += 1
+            return resp
         return {"ok": True}
 
     bot.api_request = dummy  # type: ignore
@@ -314,9 +339,9 @@ async def test_add_button(tmp_path):
             "from": {"id": 1},
         }
     })
-
-    assert any(c[0] == "editMessageReplyMarkup" for c in calls)
-
+    edit_calls = [c for c in calls if c[0] == "editMessageReplyMarkup"]
+    assert len(edit_calls) == 1
+    assert len(edit_calls[0][1]["reply_markup"]["inline_keyboard"]) == 2
 
     await bot.handle_update({
         "message": {
@@ -329,7 +354,8 @@ async def test_add_button(tmp_path):
     edit_calls = [c for c in calls if c[0] == "editMessageReplyMarkup"]
     assert len(edit_calls) == 2
     payload = edit_calls[-1][1]
-    assert payload["reply_markup"]["inline_keyboard"][0][0]["text"] == "ask locals"
+    assert len(payload["reply_markup"]["inline_keyboard"]) == 3
+    assert payload["reply_markup"]["inline_keyboard"][2][0]["text"] == "ask locals"
 
     await bot.close()
 
@@ -358,5 +384,159 @@ async def test_delete_button(tmp_path):
 
     assert calls[-1][0] == "editMessageReplyMarkup"
     assert calls[-1][1]["reply_markup"] == {}
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_add_weather_button(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        if method == "forwardMessage":
+            return {
+                "ok": True,
+                "result": {"message_id": 11, "reply_markup": {"inline_keyboard": []}},
+            }
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    bot.set_latest_weather_post(-100, 7)
+    await bot.start()
+
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'c', 0, 0)")
+    bot.db.execute(
+        "INSERT INTO weather_cache_hour (city_id, timestamp, temperature, weather_code, wind_speed, is_day) VALUES (1, ?, 15.0, 1, 3, 1)",
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    await bot.handle_update({
+        "message": {
+            "text": "/addweatherbutton https://t.me/c/123/5 K. {1|temperature}",
+            "from": {"id": 1},
+        }
+    })
+
+    assert any(c[0] == "editMessageReplyMarkup" for c in calls)
+    payload = [c[1] for c in calls if c[0] == "editMessageReplyMarkup"][0]
+    assert len(payload["reply_markup"]["inline_keyboard"]) == 1
+    assert payload["reply_markup"]["inline_keyboard"][0][0]["url"].endswith("/7")
+    assert "\u00B0C" in payload["reply_markup"]["inline_keyboard"][0][0]["text"]
+
+    calls.clear()
+    await bot.update_weather_buttons()
+    up_payload = [c[1] for c in calls if c[0] == "editMessageReplyMarkup"][0]
+    assert len(up_payload["reply_markup"]["inline_keyboard"]) == 1
+    assert "\u00B0C" in up_payload["reply_markup"]["inline_keyboard"][0][0]["text"]
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_delbutton_clears_weather_record(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        if method == "forwardMessage":
+            return {
+                "ok": True,
+                "result": {"message_id": 5, "reply_markup": {"inline_keyboard": []}},
+            }
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    bot.set_latest_weather_post(-100, 7)
+    await bot.start()
+
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'c', 0, 0)")
+    bot.db.execute(
+        "INSERT INTO weather_cache_hour (city_id, timestamp, temperature, weather_code, wind_speed, is_day) VALUES (1, ?, 15.0, 1, 3, 1)",
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    await bot.handle_update({
+        "message": {
+            "text": "/addweatherbutton https://t.me/c/123/5 K. {1|temperature}",
+            "from": {"id": 1},
+        }
+    })
+
+    assert bot.db.execute("SELECT COUNT(*) FROM weather_link_posts").fetchone()[0] == 1
+
+    await bot.handle_update({
+        "message": {
+            "text": "/delbutton https://t.me/c/123/5",
+            "from": {"id": 1},
+        }
+    })
+
+    assert bot.db.execute("SELECT COUNT(*) FROM weather_link_posts").fetchone()[0] == 0
+    assert calls[-1][0] == "editMessageReplyMarkup"
+    assert calls[-1][1]["reply_markup"] == {}
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_multiple_weather_buttons_same_row(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        if method == "forwardMessage":
+            return {
+                "ok": True,
+                "result": {"message_id": 5, "reply_markup": {"inline_keyboard": []}},
+            }
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    bot.set_latest_weather_post(-100, 7)
+    await bot.start()
+
+    bot.db.execute("INSERT INTO cities (id, name, lat, lon) VALUES (1, 'c', 0, 0)")
+    bot.db.execute(
+        "INSERT INTO weather_cache_hour (city_id, timestamp, temperature, weather_code, wind_speed, is_day) VALUES (1, ?, 15.0, 1, 3, 1)",
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    await bot.handle_update(
+        {
+            "message": {
+                "text": "/addweatherbutton https://t.me/c/123/5 A {1|temperature}",
+                "from": {"id": 1},
+            }
+        }
+    )
+
+    calls.clear()
+    await bot.handle_update(
+        {
+            "message": {
+                "text": "/addweatherbutton https://t.me/c/123/5 B {1|temperature}",
+                "from": {"id": 1},
+            }
+        }
+    )
+
+    payload = [c[1] for c in calls if c[0] == "editMessageReplyMarkup"][0]
+    assert len(payload["reply_markup"]["inline_keyboard"]) == 1
+    assert len(payload["reply_markup"]["inline_keyboard"][0]) == 2
 
     await bot.close()


### PR DESCRIPTION
## Summary
- keep previous buttons when calling `/addbutton`
- remove all buttons with `/delbutton`
- track the latest weather post and update inline weather buttons via `/addweatherbutton`
- show weather button posts in `/weatherposts`
- document new US-8.1 and US-14.1 features
- test improvements
- fix rendering for weather button templates
- delete stored weather buttons when using `/delbutton`
- group multiple weather buttons on one row

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68618bdd05a0833296a41c6e2d67d4c1