### PR TITLE
Add seastorm forecast

### DIFF
--- a/docs/weather.md
+++ b/docs/weather.md
@@ -10,11 +10,20 @@ response and the parsed weather information. The request looks like:
 https://api.open-meteo.com/v1/forecast?latitude=<lat>&longitude=<lon>&current=temperature_2m,weather_code,wind_speed_10m,is_day&timezone=auto
 ```
 
-Sea temperature uses the marine API endpoint:
+Sea conditions use the marine API endpoint:
 
 ```
-https://marine-api.open-meteo.com/v1/marine?latitude=<lat>&longitude=<lon>&hourly=sea_surface_temperature&timezone=auto
+https://api.open-meteo.com/v1/marine?latitude=<lat>&longitude=<lon>&current=wave_height,wind_speed_10m,sea_surface_temperature&hourly=wave_height,wind_speed_10m,sea_surface_temperature&forecast_days=2&timezone=auto
 ```
+
+### Storm rating
+
+The bot looks at the wave height in meters and wind speed at 10 m above the
+sea surface. When both values stay below **0.5 m** and **5 m/s** the sea is
+considered calm and `{id|seastorm}` prints the water temperature just like
+`{id|seatemperature}`. If either metric rises above those values the placeholder
+expands to `шторм`. A wave of **1.5 m** or more or wind of **10 m/s** or more
+produces `сильный шторм`.
 
 The bot continues working even if a query fails. When a request fails, it is
 retried up to three times with a one‑minute pause between attempts. After that,
@@ -46,9 +55,13 @@ no further requests are made for that city until the next scheduled half hour.
   `{<city_id>|temperature}` or `{<city_id>|wind}` mixed with text. Water
 
   temperature can be inserted with `{<sea_id>|seatemperature}` which expands to
-  the sea emoji followed by the current temperature like `🌊 15.1°C`. If the
+  the sea emoji followed by the current temperature like `🌊 15.1°C`. Storm
+  conditions are available with `{<sea_id>|seastorm}`. When waves are below
+  0.5 m and wind below 5 m/s it behaves like `{<sea_id>|seatemperature}`.
+  Values above that show `шторм`, and a wave higher than 1.5 m or wind faster
+  than 10 m/s shows `сильный шторм`.
 
-  message already contains a weather header separated by `∙` it will be stripped
+  Message text already containing a weather header separated by `∙` is stripped
   when registering so only the original text remains.
 
  - `/addweatherbutton <post_url> <text> [url]` – add a button linking to the latest forecast. Button text supports the same placeholders as templates. Provide the URL manually if no forecast exists yet. Multiple weather buttons appear on the same row.

--- a/main.py
+++ b/main.py
@@ -120,7 +120,17 @@ CREATE_TABLES = [
             morning REAL,
             day REAL,
             evening REAL,
-            night REAL
+            night REAL,
+            wave REAL,
+            wind REAL,
+            morning_wave REAL,
+            day_wave REAL,
+            evening_wave REAL,
+            night_wave REAL,
+            morning_wind REAL,
+            day_wind REAL,
+            evening_wind REAL,
+            night_wind REAL
         )""",
 
     """CREATE TABLE IF NOT EXISTS weather_posts (
@@ -213,6 +223,16 @@ class Bot:
             ("sea_cache", "day"),
             ("sea_cache", "evening"),
             ("sea_cache", "night"),
+            ("sea_cache", "wave"),
+            ("sea_cache", "wind"),
+            ("sea_cache", "morning_wave"),
+            ("sea_cache", "day_wave"),
+            ("sea_cache", "evening_wave"),
+            ("sea_cache", "night_wave"),
+            ("sea_cache", "morning_wind"),
+            ("sea_cache", "day_wind"),
+            ("sea_cache", "evening_wind"),
+            ("sea_cache", "night_wind"),
 
         ):
             cur = self.db.execute(f"PRAGMA table_info({table})")
@@ -300,10 +320,13 @@ class Bot:
 
     async def fetch_open_meteo_sea(self, lat: float, lon: float) -> dict | None:
         url = (
-            "https://marine-api.open-meteo.com/v1/marine?latitude="
-            f"{lat}&longitude={lon}&hourly=sea_surface_temperature&timezone=auto"
-
+            "https://api.open-meteo.com/v1/marine?latitude="
+            f"{lat}&longitude={lon}"
+            "&current=wave_height,wind_speed_10m,sea_surface_temperature"
+            "&hourly=wave_height,wind_speed_10m,sea_surface_temperature"
+            "&forecast_days=2&timezone=auto"
         )
+        logging.info("Sea API request: %s", url)
         try:
             async with self.session.get(url) as resp:
                 text = await resp.text()
@@ -486,33 +509,48 @@ class Bot:
                 continue
 
             data = await self.fetch_open_meteo_sea(s["lat"], s["lon"])
-            if not data or "hourly" not in data:
+            if not data or "hourly" not in data or "current" not in data:
                 continue
             temps = data["hourly"].get("water_temperature") or data["hourly"].get("sea_surface_temperature")
+            waves = data["hourly"].get("wave_height")
+            winds = data["hourly"].get("wind_speed_10m")
             times = data["hourly"].get("time")
-            if not temps or not times:
+            if not temps or not times or not waves or not winds:
                 continue
-
             current = temps[0]
+            current_wave = data["current"].get("wave_height")
+            current_wind = data["current"].get("wind_speed_10m")
             tomorrow = date.today() + timedelta(days=1)
             morn = day_temp = eve = night = None
-            for t, temp in zip(times, temps):
+            mwave = dwave = ewave = nwave = None
+            mwind = dwind = ewind = nwind = None
+            for t, temp, wave, wind in zip(times, temps, waves, winds):
                 dt = datetime.fromisoformat(t)
                 if dt.date() != tomorrow:
                     continue
                 if dt.hour == 6 and morn is None:
                     morn = temp
+                    mwave = wave
+                    mwind = wind
                 elif dt.hour == 12 and day_temp is None:
                     day_temp = temp
+                    dwave = wave
+                    dwind = wind
                 elif dt.hour == 18 and eve is None:
                     eve = temp
+                    ewave = wave
+                    ewind = wind
                 elif dt.hour == 0 and night is None:
                     night = temp
-                if morn is not None and day_temp is not None and eve is not None and night is not None:
+                    nwave = wave
+                    nwind = wind
+                if (
+                    None not in (morn, day_temp, eve, night, mwave, dwave, ewave, nwave, mwind, dwind, ewind, nwind)
+                ):
                     break
 
             self.db.execute(
-                "INSERT OR REPLACE INTO sea_cache (sea_id, updated, current, morning, day, evening, night) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO sea_cache (sea_id, updated, current, morning, day, evening, night, wave, wind, morning_wave, day_wave, evening_wave, night_wave, morning_wind, day_wind, evening_wind, night_wind) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     s["id"],
                     now.isoformat(),
@@ -521,6 +559,16 @@ class Bot:
                     day_temp,
                     eve,
                     night,
+                    current_wave,
+                    current_wind,
+                    mwave,
+                    dwave,
+                    ewave,
+                    nwave,
+                    mwind,
+                    dwind,
+                    ewind,
+                    nwind,
                 ),
             )
             self.db.commit()
@@ -688,7 +736,9 @@ class Bot:
 
     def _get_sea_cache(self, sea_id: int):
         return self.db.execute(
-            "SELECT current, morning, day, evening, night FROM sea_cache WHERE sea_id=?",
+            "SELECT current, morning, day, evening, night, wave, wind, "
+            "morning_wave, day_wave, evening_wave, night_wave, "
+            "morning_wind, day_wind, evening_wind, night_wind FROM sea_cache WHERE sea_id=?",
             (sea_id,),
         ).fetchone()
 
@@ -742,6 +792,48 @@ class Bot:
                     raise ValueError(f"no sea {key} for {cid}")
                 emoji = "\U0001F30A"
                 return f"{emoji} {row[key]:.1f}\u00B0C"
+
+            if field == "seastorm":
+                row = self._get_sea_cache(cid)
+                if not row:
+                    raise ValueError(f"no sea data for {cid}")
+                t_key = {
+                    "nm": "morning",
+                    "nd": "day",
+                    "ny": "evening",
+                    "nn": "night",
+                }.get(period, "current")
+                wave_key = {
+                    "nm": "morning_wave",
+                    "nd": "day_wave",
+                    "ny": "evening_wave",
+                    "nn": "night_wave",
+                }.get(period, "wave")
+                wind_key = {
+                    "nm": "morning_wind",
+                    "nd": "day_wind",
+                    "ny": "evening_wind",
+                    "nn": "night_wind",
+                }.get(period, "wind")
+                temp = row[t_key]
+                wave = row[wave_key]
+                wind = row[wind_key]
+                if wave is None or wind is None or temp is None:
+                    raise ValueError(f"no sea storm data for {cid}")
+
+                try:
+                    wave_val = float(wave)
+                    wind_val = float(wind)
+                    temp_val = float(temp)
+                except (TypeError, ValueError):
+                    raise ValueError(f"invalid sea storm data for {cid}")
+
+                if wave_val < 0.5 and wind_val < 5:
+                    emoji = "\U0001F30A"
+                    return f"{emoji} {temp_val:.1f}\u00B0C"
+                if wave_val >= 1.5 or wind_val >= 10:
+                    return "сильный шторм"
+                return "шторм"
 
             row = self._get_cached_weather(cid)
             period_row = self._get_period_weather(cid) if period else None

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -113,3 +113,20 @@ async def test_template_russian_and_period(tmp_path):
     assert any(m in result for m in months)
     await bot.close()
 
+
+@pytest.mark.asyncio
+async def test_seastorm_render(tmp_path):
+    bot = Bot('dummy', str(tmp_path / 'db.sqlite'))
+
+    bot.db.execute(
+        "INSERT INTO sea_cache (sea_id, updated, current, morning, day, evening, night, wave, wind, morning_wave, day_wave, evening_wave, night_wave, morning_wind, day_wind, evening_wind, night_wind)"
+        " VALUES (1, ?, 15.0, 15.1, 15.2, 15.3, 15.4, 0.2, 3.0, 0.4, 0.6, 1.6, 0.3, 4.0, 6.0, 11.0, 5.0)",
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+
+    assert bot._render_template('{1|seastorm}') == '\U0001F30A 15.0\u00B0C'
+    assert bot._render_template('{1|nd-seastorm}') == 'шторм'
+    assert bot._render_template('{1|ny-seastorm}') == 'сильный шторм'
+    await bot.close()
+


### PR DESCRIPTION
## Summary
- store wave height and wind speed in `sea_cache`
- fetch wave/wind data from Open-Meteo marine API
- classify storm conditions via `{id|seastorm}` placeholder
- document storm rating methodology
- test template rendering of new seastorm placeholder
- fix float parsing for seastorm data
- fix marine API endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_6870d527b0e88332a35b0aa51279cf3d