### PR TITLE
Add seastorm icon and preserve text

### DIFF
--- a/docs/weather.md
+++ b/docs/weather.md
@@ -10,11 +10,18 @@ response and the parsed weather information. The request looks like:
 https://api.open-meteo.com/v1/forecast?latitude=<lat>&longitude=<lon>&current=temperature_2m,weather_code,wind_speed_10m,is_day&timezone=auto
 ```
 
-Sea temperature uses the marine API endpoint:
+Sea conditions use the marine API endpoint:
 
 ```
-https://marine-api.open-meteo.com/v1/marine?latitude=<lat>&longitude=<lon>&hourly=sea_surface_temperature&timezone=auto
+https://marine-api.open-meteo.com/v1/marine?latitude=<lat>&longitude=<lon>&current=wave_height,wind_wave_height,swell_wave_height,sea_surface_temperature,sea_level_height_msl&hourly=wave_height,wind_wave_height,swell_wave_height,sea_surface_temperature&daily=wave_height_max,wind_wave_height_max,swell_wave_height_max&forecast_days=2&timezone=auto
 ```
+
+### Storm rating
+
+The bot looks at the wave height in meters. When it stays below **0.5 m** the
+sea is considered calm and `{id|seastorm}` prints the water temperature just
+like `{id|seatemperature}`. Waves from **0.5 m** to **1.5 m** produce
+`шторм`. Anything higher than **1.5 m** results in `сильный шторм`.
 
 The bot continues working even if a query fails. When a request fails, it is
 retried up to three times with a one‑minute pause between attempts. After that,
@@ -46,9 +53,12 @@ no further requests are made for that city until the next scheduled half hour.
   `{<city_id>|temperature}` or `{<city_id>|wind}` mixed with text. Water
 
   temperature can be inserted with `{<sea_id>|seatemperature}` which expands to
-  the sea emoji followed by the current temperature like `🌊 15.1°C`. If the
+  the sea emoji followed by the current temperature like `🌊 15.1°C`. Storm
+  conditions are available with `{<sea_id>|seastorm}`. Waves below 0.5 m behave
+  like `{<sea_id>|seatemperature}`. Heights between 0.5 m and 1.5 m show
+  `🌊 шторм`, while anything above 1.5 m shows `🌊 сильный шторм`.
 
-  message already contains a weather header separated by `∙` it will be stripped
+  Message text already containing a weather header separated by `∙` is stripped
   when registering so only the original text remains.
 
  - `/addweatherbutton <post_url> <text> [url]` – add a button linking to the latest forecast. Button text supports the same placeholders as templates. Provide the URL manually if no forecast exists yet. Multiple weather buttons appear on the same row.
@@ -129,7 +139,12 @@ CREATE TABLE IF NOT EXISTS sea_cache (
     morning REAL,
     day REAL,
     evening REAL,
-    night REAL
+    night REAL,
+    wave REAL,
+    morning_wave REAL,
+    day_wave REAL,
+    evening_wave REAL,
+    night_wave REAL
 );
 ```
 

--- a/main.py
+++ b/main.py
@@ -120,7 +120,12 @@ CREATE_TABLES = [
             morning REAL,
             day REAL,
             evening REAL,
-            night REAL
+            night REAL,
+            wave REAL,
+            morning_wave REAL,
+            day_wave REAL,
+            evening_wave REAL,
+            night_wave REAL
         )""",
 
     """CREATE TABLE IF NOT EXISTS weather_posts (
@@ -213,6 +218,11 @@ class Bot:
             ("sea_cache", "day"),
             ("sea_cache", "evening"),
             ("sea_cache", "night"),
+            ("sea_cache", "wave"),
+            ("sea_cache", "morning_wave"),
+            ("sea_cache", "day_wave"),
+            ("sea_cache", "evening_wave"),
+            ("sea_cache", "night_wave"),
 
         ):
             cur = self.db.execute(f"PRAGMA table_info({table})")
@@ -301,9 +311,15 @@ class Bot:
     async def fetch_open_meteo_sea(self, lat: float, lon: float) -> dict | None:
         url = (
             "https://marine-api.open-meteo.com/v1/marine?latitude="
-            f"{lat}&longitude={lon}&hourly=sea_surface_temperature&timezone=auto"
-
+            f"{lat}&longitude={lon}"
+            "&current=wave_height,wind_wave_height,swell_wave_height,"
+            "sea_surface_temperature,sea_level_height_msl"
+            "&hourly=wave_height,wind_wave_height,swell_wave_height,"
+            "sea_surface_temperature"
+            "&daily=wave_height_max,wind_wave_height_max,swell_wave_height_max"
+            "&forecast_days=2&timezone=auto"
         )
+        logging.info("Sea API request: %s", url)
         try:
             async with self.session.get(url) as resp:
                 text = await resp.text()
@@ -486,33 +502,41 @@ class Bot:
                 continue
 
             data = await self.fetch_open_meteo_sea(s["lat"], s["lon"])
-            if not data or "hourly" not in data:
+            if not data or "hourly" not in data or "current" not in data:
                 continue
             temps = data["hourly"].get("water_temperature") or data["hourly"].get("sea_surface_temperature")
+            waves = data["hourly"].get("wave_height")
             times = data["hourly"].get("time")
-            if not temps or not times:
+            if not temps or not times or not waves:
                 continue
-
             current = temps[0]
+            current_wave = data["current"].get("wave_height")
             tomorrow = date.today() + timedelta(days=1)
             morn = day_temp = eve = night = None
-            for t, temp in zip(times, temps):
+            mwave = dwave = ewave = nwave = None
+            for t, temp, wave in zip(times, temps, waves):
                 dt = datetime.fromisoformat(t)
                 if dt.date() != tomorrow:
                     continue
                 if dt.hour == 6 and morn is None:
                     morn = temp
+                    mwave = wave
                 elif dt.hour == 12 and day_temp is None:
                     day_temp = temp
+                    dwave = wave
                 elif dt.hour == 18 and eve is None:
                     eve = temp
+                    ewave = wave
                 elif dt.hour == 0 and night is None:
                     night = temp
-                if morn is not None and day_temp is not None and eve is not None and night is not None:
+                    nwave = wave
+                if (
+                    None not in (morn, day_temp, eve, night, mwave, dwave, ewave, nwave)
+                ):
                     break
 
             self.db.execute(
-                "INSERT OR REPLACE INTO sea_cache (sea_id, updated, current, morning, day, evening, night) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO sea_cache (sea_id, updated, current, morning, day, evening, night, wave, morning_wave, day_wave, evening_wave, night_wave) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     s["id"],
                     now.isoformat(),
@@ -521,6 +545,11 @@ class Bot:
                     day_temp,
                     eve,
                     night,
+                    current_wave,
+                    mwave,
+                    dwave,
+                    ewave,
+                    nwave,
                 ),
             )
             self.db.commit()
@@ -688,9 +717,23 @@ class Bot:
 
     def _get_sea_cache(self, sea_id: int):
         return self.db.execute(
-            "SELECT current, morning, day, evening, night FROM sea_cache WHERE sea_id=?",
+            "SELECT current, morning, day, evening, night, wave, "
+            "morning_wave, day_wave, evening_wave, night_wave FROM sea_cache WHERE sea_id=?",
             (sea_id,),
         ).fetchone()
+
+    @staticmethod
+    def strip_header(text: str | None) -> str | None:
+        """Remove an existing weather header from text if detected."""
+        if not text:
+            return text
+        if WEATHER_SEPARATOR not in text:
+            return text
+        first, rest = text.split(WEATHER_SEPARATOR, 1)
+        first = first.strip()
+        if "\u00B0C" in first or "шторм" in first:
+            return rest.lstrip()
+        return text
 
 
     @staticmethod
@@ -742,6 +785,40 @@ class Bot:
                     raise ValueError(f"no sea {key} for {cid}")
                 emoji = "\U0001F30A"
                 return f"{emoji} {row[key]:.1f}\u00B0C"
+
+            if field == "seastorm":
+                row = self._get_sea_cache(cid)
+                if not row:
+                    raise ValueError(f"no sea data for {cid}")
+                t_key = {
+                    "nm": "morning",
+                    "nd": "day",
+                    "ny": "evening",
+                    "nn": "night",
+                }.get(period, "current")
+                wave_key = {
+                    "nm": "morning_wave",
+                    "nd": "day_wave",
+                    "ny": "evening_wave",
+                    "nn": "night_wave",
+                }.get(period, "wave")
+                temp = row[t_key]
+                wave = row[wave_key]
+                if wave is None or temp is None:
+                    raise ValueError(f"no sea storm data for {cid}")
+
+                try:
+                    wave_val = float(wave)
+                    temp_val = float(temp)
+                except (TypeError, ValueError):
+                    raise ValueError(f"invalid sea storm data for {cid}")
+
+                emoji = "\U0001F30A"
+                if wave_val < 0.5:
+                    return f"{emoji} {temp_val:.1f}\u00B0C"
+                if wave_val >= 1.5:
+                    return f"{emoji} сильный шторм"
+                return f"{emoji} шторм"
 
             row = self._get_cached_weather(cid)
             period_row = self._get_period_weather(cid) if period else None
@@ -828,7 +905,7 @@ class Bot:
             else:
                 text = (
                     f"{header}{WEATHER_SEPARATOR}{r['base_text']}"
-                    if r["base_text"]
+                    if r["base_text"] is not None
                     else header
                 )
 
@@ -1801,27 +1878,47 @@ class Bot:
                 return
             template = parts[2]
             chat_id, msg_id = parsed
-            resp = await self.api_request('copyMessage', {
-                'chat_id': user_id,
-                'from_chat_id': chat_id,
-                'message_id': msg_id
-            })
-            if not resp.get('ok'):
-                resp = await self.api_request('forwardMessage', {
+            resp = await self.api_request(
+                'copyMessage',
+                {
                     'chat_id': user_id,
                     'from_chat_id': chat_id,
-                    'message_id': msg_id
-                })
+                    'message_id': msg_id,
+                },
+            )
+            if not resp.get('ok'):
+                resp = await self.api_request(
+                    'forwardMessage',
+                    {
+                        'chat_id': user_id,
+                        'from_chat_id': chat_id,
+                        'message_id': msg_id,
+                    },
+                )
+            elif (
+                not resp['result'].get('text')
+                and not resp['result'].get('caption')
+            ):
+                await self.api_request(
+                    'deleteMessage',
+                    {'chat_id': user_id, 'message_id': resp['result']['message_id']},
+                )
+                resp = await self.api_request(
+                    'forwardMessage',
+                    {
+                        'chat_id': user_id,
+                        'from_chat_id': chat_id,
+                        'message_id': msg_id,
+                    },
+                )
             if not resp.get('ok'):
                 await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Cannot read post'})
                 return
 
             base_text = resp['result'].get('text')
             base_caption = resp['result'].get('caption')
-            if base_text and WEATHER_SEPARATOR in base_text:
-                base_text = base_text.split(WEATHER_SEPARATOR, 1)[1]
-            if base_caption and WEATHER_SEPARATOR in base_caption:
-                base_caption = base_caption.split(WEATHER_SEPARATOR, 1)[1]
+            base_text = self.strip_header(base_text)
+            base_caption = self.strip_header(base_caption)
             markup = resp['result'].get('reply_markup')
 
             if base_text is None and base_caption is None:

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -113,3 +113,25 @@ async def test_template_russian_and_period(tmp_path):
     assert any(m in result for m in months)
     await bot.close()
 
+
+@pytest.mark.asyncio
+async def test_seastorm_render(tmp_path):
+    bot = Bot('dummy', str(tmp_path / 'db.sqlite'))
+
+    bot.db.execute(
+        "INSERT INTO sea_cache (sea_id, updated, current, morning, day, evening, night, wave, morning_wave, day_wave, evening_wave, night_wave)"
+        " VALUES (1, ?, 15.0, 15.1, 15.2, 15.3, 15.4, 0.2, 0.4, 0.6, 1.6, 0.3)",
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+
+    assert bot._render_template('{1|seastorm}') == '\U0001F30A 15.0\u00B0C'
+    assert bot._render_template('{1|nd-seastorm}') == '\U0001F30A шторм'
+    assert bot._render_template('{1|ny-seastorm}') == '\U0001F30A сильный шторм'
+    await bot.close()
+
+
+def test_strip_header():
+    assert Bot.strip_header('🌊 16°C∙text') == 'text'
+    assert Bot.strip_header('prefix ∙ data') == 'prefix ∙ data'
+


### PR DESCRIPTION
## Summary
- prefix storm messages with the wave emoji
- keep base text when updating weather posts even if empty
- document storm output with emoji
- update seastorm unit test
- strip weather headers more carefully when registering posts
- retry with forwardMessage when copyMessage lacks text or caption

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6870d527b0e88332a35b0aa51279cf3d