### PR TITLE
Add amber storm notification

### DIFF
--- a/migrations/0006_amber.sql
+++ b/migrations/0006_amber.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS amber_channels (
+    channel_id INTEGER PRIMARY KEY
+);
+CREATE TABLE IF NOT EXISTS amber_state (
+    sea_id INTEGER PRIMARY KEY,
+    storm_start TEXT,
+    active INTEGER DEFAULT 0
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import asyncio
+import pytest
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: run test in event loop")
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    if asyncio.iscoroutinefunction(pyfuncitem.obj):
+        loop = pyfuncitem.funcargs.get('event_loop') or asyncio.get_event_loop()
+        kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+        loop.run_until_complete(pyfuncitem.obj(**kwargs))
+        return True
+    return None


### PR DESCRIPTION
## Summary
- notify configured channels when a strong sea storm ends
- allow admins to configure amber alerts via `/amber`
- store amber alert settings and channels in new tables
- cover amber notification logic with a new test

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: unable to open database file, assert False, KeyError: 'result', ClientConnectorError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a70d3318408332b222cbf214ecad5d