### PR TITLE
Add async job queue and media ingestion pipeline

### DIFF
--- a/data_access.py
+++ b/data_access.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable
+
+import sqlite3
+
+
+@dataclass
+class Asset:
+    id: int
+    channel_id: int
+    message_id: int
+    caption_template: str | None
+    hashtags: str | None
+    categories: list[str]
+    recognized_message_id: int | None
+    metadata: dict[str, Any] | None
+    vision_results: dict[str, Any] | None
+    latitude: float | None
+    longitude: float | None
+    city: str | None
+    country: str | None
+
+
+@dataclass
+class WeatherJob:
+    id: int
+    channel_id: int
+    post_time: str
+    run_at: datetime
+    last_run_at: datetime | None
+    failures: int
+    last_error: str | None
+
+
+class DataAccess:
+    """High level helpers for working with the SQLite database."""
+
+    def __init__(self, connection: sqlite3.Connection):
+        self.conn = connection
+        self.conn.row_factory = sqlite3.Row
+        self._ensure_tables()
+
+    def _ensure_tables(self) -> None:
+        now = datetime.utcnow().isoformat()
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel_id INTEGER NOT NULL,
+                message_id INTEGER NOT NULL UNIQUE,
+                caption_template TEXT,
+                hashtags TEXT,
+                categories TEXT,
+                recognized_message_id INTEGER,
+                metadata TEXT,
+                vision_results TEXT,
+                latitude REAL,
+                longitude REAL,
+                city TEXT,
+                country TEXT,
+                last_used_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS asset_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel_id INTEGER NOT NULL,
+                message_id INTEGER NOT NULL,
+                asset_id INTEGER,
+                schedule_id INTEGER,
+                metadata TEXT,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS weather_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel_id INTEGER NOT NULL UNIQUE,
+                post_time TEXT NOT NULL,
+                run_at TEXT NOT NULL,
+                last_run_at TEXT,
+                failures INTEGER DEFAULT 0,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobs_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                payload TEXT,
+                status TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                available_at TEXT,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ai_usage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                model TEXT NOT NULL,
+                prompt_tokens INTEGER,
+                completion_tokens INTEGER,
+                total_tokens INTEGER,
+                job_name TEXT,
+                job_id INTEGER,
+                asset_id INTEGER,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        # ensure indexes for frequent lookups
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_assets_message ON assets(message_id)"
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_jobs_queue_status ON jobs_queue(status, available_at)"
+        )
+        self.conn.commit()
+
+    @staticmethod
+    def _serialize_categories(hashtags: str | None, categories: Iterable[str] | None) -> str:
+        if categories is not None:
+            cats = list(dict.fromkeys(categories))
+        elif hashtags:
+            cats = [tag.strip() for tag in hashtags.split() if tag.strip()]
+        else:
+            cats = []
+        return json.dumps(cats)
+
+    def save_asset(
+        self,
+        channel_id: int,
+        message_id: int,
+        template: str | None,
+        hashtags: str | None,
+        *,
+        metadata: dict[str, Any] | None = None,
+        categories: Iterable[str] | None = None,
+    ) -> int:
+        """Insert or update asset metadata."""
+
+        now = datetime.utcnow().isoformat()
+        cats_json = self._serialize_categories(hashtags, categories)
+        metadata_json = json.dumps(metadata) if metadata is not None else None
+        cur = self.conn.execute(
+            """
+            INSERT INTO assets (
+                channel_id, message_id, caption_template, hashtags, categories,
+                metadata, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(message_id) DO UPDATE SET
+                channel_id=excluded.channel_id,
+                caption_template=excluded.caption_template,
+                hashtags=excluded.hashtags,
+                categories=excluded.categories,
+                metadata=COALESCE(excluded.metadata, assets.metadata),
+                updated_at=excluded.updated_at
+            """,
+            (
+                channel_id,
+                message_id,
+                template,
+                hashtags,
+                cats_json,
+                metadata_json,
+                now,
+                now,
+            ),
+        )
+        self.conn.commit()
+        if cur.lastrowid:
+            return int(cur.lastrowid)
+        row = self.get_asset_by_message(message_id)
+        return row.id if row else 0
+
+    def update_asset(
+        self,
+        asset_id: int,
+        *,
+        template: str | None = None,
+        hashtags: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        recognized_message_id: int | None = None,
+        vision_results: dict[str, Any] | None = None,
+        latitude: float | None = None,
+        longitude: float | None = None,
+        city: str | None = None,
+        country: str | None = None,
+    ) -> None:
+        """Update selected asset fields while preserving unset values."""
+
+        row = self.get_asset(asset_id)
+        if not row:
+            logging.warning("Attempted to update missing asset %s", asset_id)
+            return
+        values: dict[str, Any] = {}
+        if template is not None:
+            values["caption_template"] = template
+        if hashtags is not None:
+            values["hashtags"] = hashtags
+            values["categories"] = self._serialize_categories(hashtags, None)
+        if metadata is not None:
+            existing = row.metadata or {}
+            merged = existing.copy()
+            merged.update(metadata)
+            values["metadata"] = json.dumps(merged)
+        if recognized_message_id is not None:
+            values["recognized_message_id"] = recognized_message_id
+        if vision_results is not None:
+            values["vision_results"] = json.dumps(vision_results)
+        if latitude is not None:
+            values["latitude"] = latitude
+        if longitude is not None:
+            values["longitude"] = longitude
+        if city is not None:
+            values["city"] = city
+        if country is not None:
+            values["country"] = country
+        if not values:
+            return
+        assignments = ", ".join(f"{k} = ?" for k in values)
+        params: list[Any] = list(values.values())
+        params.append(asset_id)
+        sql = f"UPDATE assets SET {assignments}, updated_at=? WHERE id=?"
+        params.insert(-1, datetime.utcnow().isoformat())
+        self.conn.execute(sql, params)
+        self.conn.commit()
+
+    def get_asset(self, asset_id: int) -> Asset | None:
+        row = self.conn.execute(
+            "SELECT * FROM assets WHERE id=?", (asset_id,)
+        ).fetchone()
+        return self._asset_from_row(row) if row else None
+
+    def get_asset_by_message(self, message_id: int) -> Asset | None:
+        row = self.conn.execute(
+            "SELECT * FROM assets WHERE message_id=?", (message_id,)
+        ).fetchone()
+        return self._asset_from_row(row) if row else None
+
+    def _asset_from_row(self, row: sqlite3.Row | None) -> Asset | None:
+        if not row:
+            return None
+        categories = json.loads(row["categories"] or "[]")
+        metadata = json.loads(row["metadata"] or "null")
+        vision = json.loads(row["vision_results"] or "null")
+        return Asset(
+            id=row["id"],
+            channel_id=row["channel_id"],
+            message_id=row["message_id"],
+            caption_template=row["caption_template"],
+            hashtags=row["hashtags"],
+            categories=categories,
+            recognized_message_id=row["recognized_message_id"],
+            metadata=metadata,
+            vision_results=vision,
+            latitude=row["latitude"],
+            longitude=row["longitude"],
+            city=row["city"],
+            country=row["country"],
+        )
+
+    def get_next_asset(self, tags: set[str] | None) -> Asset | None:
+        now_iso = datetime.utcnow().isoformat()
+        rows = self.conn.execute(
+            "SELECT * FROM assets ORDER BY COALESCE(last_used_at, created_at) ASC"
+        ).fetchall()
+        normalized = {t.lower() for t in tags} if tags else None
+        for row in rows:
+            asset = self._asset_from_row(row)
+            if not asset:
+                continue
+            if normalized:
+                asset_tags = {t.lower() for t in asset.categories}
+                if not asset_tags.intersection(normalized):
+                    continue
+            self.conn.execute(
+                "UPDATE assets SET last_used_at=?, updated_at=? WHERE id=?",
+                (now_iso, now_iso, asset.id),
+            )
+            self.conn.commit()
+            return asset
+        return None
+
+    def record_post_history(
+        self,
+        channel_id: int,
+        message_id: int,
+        asset_id: int | None,
+        schedule_id: int | None,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        now = datetime.utcnow().isoformat()
+        self.conn.execute(
+            """
+            INSERT INTO asset_history (
+                channel_id, message_id, asset_id, schedule_id, metadata, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                channel_id,
+                message_id,
+                asset_id,
+                schedule_id,
+                json.dumps(metadata) if metadata is not None else None,
+                now,
+            ),
+        )
+        self.conn.commit()
+
+    def upsert_weather_job(self, channel_id: int, post_time: str, next_run: datetime) -> None:
+        now = datetime.utcnow().isoformat()
+        run_iso = next_run.isoformat()
+        self.conn.execute(
+            """
+            INSERT INTO weather_jobs (channel_id, post_time, run_at, last_run_at, failures, last_error, created_at, updated_at)
+            VALUES (?, ?, ?, NULL, 0, NULL, ?, ?)
+            ON CONFLICT(channel_id) DO UPDATE SET
+                post_time=excluded.post_time,
+                run_at=excluded.run_at,
+                updated_at=excluded.updated_at
+            """,
+            (channel_id, post_time, run_iso, now, now),
+        )
+        self.conn.commit()
+
+    def remove_weather_job(self, channel_id: int) -> None:
+        self.conn.execute("DELETE FROM weather_jobs WHERE channel_id=?", (channel_id,))
+        self.conn.commit()
+
+    def list_weather_jobs(self) -> list[WeatherJob]:
+        rows = self.conn.execute(
+            "SELECT * FROM weather_jobs ORDER BY channel_id"
+        ).fetchall()
+        return [self._weather_job_from_row(r) for r in rows]
+
+    def _weather_job_from_row(self, row: sqlite3.Row) -> WeatherJob:
+        return WeatherJob(
+            id=row["id"],
+            channel_id=row["channel_id"],
+            post_time=row["post_time"],
+            run_at=datetime.fromisoformat(row["run_at"]),
+            last_run_at=datetime.fromisoformat(row["last_run_at"])
+            if row["last_run_at"]
+            else None,
+            failures=row["failures"] or 0,
+            last_error=row["last_error"],
+        )
+
+    def due_weather_jobs(self, now: datetime) -> list[WeatherJob]:
+        rows = self.conn.execute(
+            "SELECT * FROM weather_jobs WHERE run_at <= ? ORDER BY run_at",
+            (now.isoformat(),),
+        ).fetchall()
+        return [self._weather_job_from_row(r) for r in rows]
+
+    def mark_weather_job_run(self, job_id: int, next_run: datetime) -> None:
+        now = datetime.utcnow().isoformat()
+        self.conn.execute(
+            """
+            UPDATE weather_jobs
+            SET run_at=?, last_run_at=?, failures=0, last_error=NULL, updated_at=?
+            WHERE id=?
+            """,
+            (next_run.isoformat(), now, now, job_id),
+        )
+        self.conn.commit()
+
+    def record_weather_job_failure(self, job_id: int, reason: str) -> None:
+        now = datetime.utcnow().isoformat()
+        self.conn.execute(
+            """
+            UPDATE weather_jobs
+            SET failures=COALESCE(failures, 0) + 1, last_error=?, updated_at=?
+            WHERE id=?
+            """,
+            (reason, now, job_id),
+        )
+        self.conn.commit()
+
+    def log_ai_usage(
+        self,
+        model: str,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+        total_tokens: int | None,
+        *,
+        job_name: str | None = None,
+        job_id: int | None = None,
+        asset_id: int | None = None,
+    ) -> None:
+        now = datetime.utcnow().isoformat()
+        self.conn.execute(
+            """
+            INSERT INTO ai_usage (
+                model, prompt_tokens, completion_tokens, total_tokens,
+                job_name, job_id, asset_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (model, prompt_tokens, completion_tokens, total_tokens, job_name, job_id, asset_id, now),
+        )
+        self.conn.commit()

--- a/jobs.py
+++ b/jobs.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Awaitable, Callable, Dict
+
+import sqlite3
+
+JobHandler = Callable[["Job"], Awaitable[None]]
+
+
+@dataclass
+class Job:
+    id: int
+    name: str
+    payload: dict[str, Any]
+    status: str
+    attempts: int
+    available_at: datetime | None
+    last_error: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class JobQueue:
+    """Simple persistent job queue backed by SQLite."""
+
+    STATUSES = {"queued", "running", "done", "failed", "delayed"}
+
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        concurrency: int = 1,
+        poll_interval: float = 1.0,
+        max_attempts: int = 5,
+    ) -> None:
+        self.conn = connection
+        self.conn.row_factory = sqlite3.Row
+        self.concurrency = max(1, concurrency)
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        self.handlers: Dict[str, JobHandler] = {}
+        self._queue: asyncio.Queue[Job] = asyncio.Queue()
+        self._workers: list[asyncio.Task] = []
+        self._loader: asyncio.Task | None = None
+        self._running = False
+        self._inflight: set[int] = set()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def register_handler(self, name: str, handler: JobHandler) -> None:
+        self.handlers[name] = handler
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._loop = asyncio.get_running_loop()
+        await self._load_due_jobs()
+        self._loader = asyncio.create_task(self._loader_loop())
+        for _ in range(self.concurrency):
+            self._workers.append(asyncio.create_task(self._worker_loop()))
+
+    async def stop(self) -> None:
+        if not self._running:
+            return
+        self._running = False
+        if self._loader:
+            self._loader.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._loader
+        for _ in self._workers:
+            await self._queue.put(None)  # type: ignore[arg-type]
+        for task in self._workers:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        self._workers.clear()
+        self._loader = None
+        self._inflight.clear()
+
+    async def _loader_loop(self) -> None:
+        try:
+            while self._running:
+                await self._load_due_jobs()
+                await asyncio.sleep(self.poll_interval)
+        except asyncio.CancelledError:
+            pass
+
+    async def _worker_loop(self) -> None:
+        try:
+            while self._running:
+                job = await self._queue.get()
+                if job is None:
+                    break
+                await self._execute_job(job)
+                self._queue.task_done()
+        except asyncio.CancelledError:
+            pass
+
+    async def _execute_job(self, job: Job) -> None:
+        handler = self.handlers.get(job.name)
+        if not handler:
+            logging.error("No handler registered for job %s", job.name)
+            await self._mark_failed(job, "handler missing")
+            self._inflight.discard(job.id)
+            return
+        start = datetime.utcnow().isoformat()
+        self.conn.execute(
+            "UPDATE jobs_queue SET status=?, updated_at=? WHERE id=?",
+            ("running", start, job.id),
+        )
+        self.conn.commit()
+        try:
+            await handler(job)
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.exception("Job %s failed", job.id)
+            await self._handle_failure(job, str(exc))
+        else:
+            self.conn.execute(
+                "UPDATE jobs_queue SET status=?, last_error=NULL, updated_at=? WHERE id=?",
+                ("done", datetime.utcnow().isoformat(), job.id),
+            )
+            self.conn.commit()
+        finally:
+            self._inflight.discard(job.id)
+
+    async def _handle_failure(self, job: Job, error: str) -> None:
+        attempts = job.attempts + 1
+        if attempts >= self.max_attempts:
+            await self._mark_failed(job, error, attempts)
+            return
+        delay_seconds = min(3600, 2 ** attempts)
+        available_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
+        self.conn.execute(
+            """
+            UPDATE jobs_queue
+            SET status=?, attempts=?, available_at=?, last_error=?, updated_at=?
+            WHERE id=?
+            """,
+            (
+                "delayed",
+                attempts,
+                available_at.isoformat(),
+                error,
+                datetime.utcnow().isoformat(),
+                job.id,
+            ),
+        )
+        self.conn.commit()
+
+    async def _mark_failed(self, job: Job, error: str, attempts: int | None = None) -> None:
+        self.conn.execute(
+            "UPDATE jobs_queue SET status=?, attempts=?, last_error=?, updated_at=? WHERE id=?",
+            (
+                "failed",
+                attempts if attempts is not None else job.attempts + 1,
+                error,
+                datetime.utcnow().isoformat(),
+                job.id,
+            ),
+        )
+        self.conn.commit()
+
+    async def _load_due_jobs(self) -> None:
+        now = datetime.utcnow().isoformat()
+        rows = self.conn.execute(
+            """
+            SELECT * FROM jobs_queue
+            WHERE status IN ('queued', 'delayed')
+              AND (available_at IS NULL OR available_at <= ?)
+            ORDER BY created_at, id
+            """,
+            (now,),
+        ).fetchall()
+        for row in rows:
+            job_id = int(row["id"])
+            if job_id in self._inflight:
+                continue
+            status = row["status"]
+            if status == "delayed":
+                self.conn.execute(
+                    "UPDATE jobs_queue SET status=?, updated_at=? WHERE id=?",
+                    ("queued", datetime.utcnow().isoformat(), job_id),
+                )
+                self.conn.commit()
+            job = self._row_to_job(row)
+            self._inflight.add(job_id)
+            await self._queue.put(job)
+
+    def _row_to_job(self, row: sqlite3.Row) -> Job:
+        payload = row["payload"]
+        data = json.loads(payload) if payload else {}
+        available = (
+            datetime.fromisoformat(row["available_at"])
+            if row["available_at"]
+            else None
+        )
+        return Job(
+            id=row["id"],
+            name=row["name"],
+            payload=data,
+            status=row["status"],
+            attempts=row["attempts"],
+            available_at=available,
+            last_error=row["last_error"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def enqueue(
+        self,
+        name: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        run_at: datetime | None = None,
+    ) -> int:
+        if name not in self.handlers:
+            logging.warning("Enqueuing job %s without registered handler", name)
+        now = datetime.utcnow()
+        available_at = run_at if run_at else now
+        status = "queued" if available_at <= now else "delayed"
+        cur = self.conn.execute(
+            """
+            INSERT INTO jobs_queue (name, payload, status, attempts, available_at, created_at, updated_at)
+            VALUES (?, ?, ?, 0, ?, ?, ?)
+            """,
+            (
+                name,
+                json.dumps(payload or {}),
+                status,
+                available_at.isoformat() if status == "delayed" else None,
+                now.isoformat(),
+                now.isoformat(),
+            ),
+        )
+        self.conn.commit()
+        job_id = int(cur.lastrowid)
+        if status == "queued" and self._running:
+            row = self.conn.execute(
+                "SELECT * FROM jobs_queue WHERE id=?", (job_id,)
+            ).fetchone()
+            if row:
+                job = self._row_to_job(row)
+                self._inflight.add(job_id)
+                loop = self._loop or asyncio.get_running_loop()
+                loop.call_soon(self._queue.put_nowait, job)
+        return job_id

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import httpx
+
+
+@dataclass
+class OpenAIResponse:
+    content: Dict[str, Any]
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    total_tokens: int | None
+
+
+class OpenAIClient:
+    """Minimal OpenAI wrapper that tracks token usage."""
+
+    def __init__(self, api_key: str | None, *, base_url: str | None = None) -> None:
+        self.api_key = api_key
+        self.base_url = base_url or "https://api.openai.com/v1"
+        if not self.api_key:
+            logging.warning("OpenAI API key not configured; vision tasks will be skipped")
+
+    async def classify_image(
+        self,
+        *,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        image_bytes: bytes,
+        schema: dict[str, Any],
+    ) -> OpenAIResponse | None:
+        if not self.api_key:
+            return None
+        url = f"{self.base_url}/responses"
+        payload = {
+            "model": model,
+            "input": [
+                {
+                    "role": "system",
+                    "content": system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user_prompt},
+                        {
+                            "type": "input_image",
+                            "image_base64": base64.b64encode(image_bytes).decode("ascii"),
+                        },
+                    ],
+                },
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": schema,
+            },
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=120) as client:
+            response = await client.post(url, json=payload, headers=headers)
+        if response.status_code != 200:
+            logging.error("OpenAI API error %s: %s", response.status_code, response.text)
+            raise RuntimeError(f"OpenAI API error {response.status_code}")
+        data = response.json()
+        usage = data.get("usage") or {}
+        prompt_tokens = usage.get("prompt_tokens")
+        completion_tokens = usage.get("completion_tokens")
+        total_tokens = usage.get("total_tokens")
+        content = data.get("output") or data.get("response") or {}
+        # API returns list under "output"; normalise
+        if isinstance(content, list) and content:
+            content_item = content[0]
+        else:
+            content_item = content
+        if isinstance(content_item, dict) and "content" in content_item:
+            segments = content_item["content"]
+            if isinstance(segments, list) and segments:
+                message_text = segments[0].get("text")
+            else:
+                message_text = content_item.get("content")
+        elif isinstance(content_item, str):
+            message_text = content_item
+        else:
+            message_text = None
+        parsed: Dict[str, Any]
+        if message_text:
+            try:
+                parsed = json.loads(message_text)
+            except json.JSONDecodeError:
+                parsed = {"raw": message_text}
+        else:
+            parsed = {}
+        return OpenAIResponse(parsed, prompt_tokens, completion_tokens, total_tokens)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 aiohttp>=3.9.5
+httpx>=0.27.0
+Pillow>=10.4.0
+piexif>=1.1.3


### PR DESCRIPTION
## Summary
- introduce a persistent SQLite-backed job queue with exponential backoff and status tracking for ingest/vision jobs
- extend data access layer and bot workflow to capture Telegram asset metadata, schedule ingest jobs, and process results including EXIF/geocoding and OpenAI vision responses
- add OpenAI HTTP client wrapper plus new dependencies for image/EXIF handling and logging of AI usage

## Testing
- `pytest -q` *(fails: missing Pillow dependency due to offline environment)*


------
https://chatgpt.com/codex/tasks/task_e_68df8bc7af608332b793bdaec07bd4b7