### PR TITLE
Update vision pipeline with structured schema and storage

### DIFF
--- a/migrations/0008_vision_enhancements.sql
+++ b/migrations/0008_vision_enhancements.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE assets ADD COLUMN vision_category TEXT;
+ALTER TABLE assets ADD COLUMN vision_arch_view TEXT;
+ALTER TABLE assets ADD COLUMN vision_photo_weather TEXT;
+ALTER TABLE assets ADD COLUMN vision_flower_varieties TEXT;
+ALTER TABLE assets ADD COLUMN vision_confidence REAL;
+
+ALTER TABLE vision_results ADD COLUMN category TEXT;
+ALTER TABLE vision_results ADD COLUMN arch_view TEXT;
+ALTER TABLE vision_results ADD COLUMN photo_weather TEXT;
+ALTER TABLE vision_results ADD COLUMN flower_varieties TEXT;
+ALTER TABLE vision_results ADD COLUMN confidence REAL;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- request structured vision results (category, architecture view, weather, flowers, confidence) in the vision job prompt
- persist structured vision outputs in the assets table and detailed columns in vision_results
- rebuild the recognition caption to surface location, classification, and in-photo weather details

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68dfae70aa148332b024b35f6eb1d04e