### PR TITLE
Add rubric scheduler and publication workflows

### DIFF
--- a/migrations/0008_rubric_scheduler.sql
+++ b/migrations/0008_rubric_scheduler.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS rubric_schedule_state (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    rubric_code TEXT NOT NULL,
+    schedule_key TEXT NOT NULL,
+    next_run_at TEXT,
+    last_run_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(rubric_code, schedule_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rubric_schedule_state_code
+    ON rubric_schedule_state(rubric_code, schedule_key);
+
+COMMIT;

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -1,0 +1,165 @@
+import json
+import os
+import sys
+from datetime import datetime
+
+import pytest
+from PIL import Image
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from main import Bot
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+
+
+def _insert_rubric(bot: Bot, code: str, config: dict, rubric_id: int = 1) -> None:
+    now = datetime.utcnow().isoformat()
+    bot.db.execute(
+        """
+        INSERT INTO rubrics (id, code, title, description, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(code) DO UPDATE SET description=excluded.description, updated_at=excluded.updated_at
+        """,
+        (
+            rubric_id,
+            code,
+            code.title(),
+            json.dumps(config),
+            now,
+            now,
+        ),
+    )
+    bot.db.commit()
+
+
+@pytest.mark.asyncio
+async def test_rubric_scheduler_enqueues_jobs(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+    config = {
+        "enabled": True,
+        "tz": "+00:00",
+        "schedules": [
+            {"time": "00:00", "channel_id": -100}
+        ],
+        "assets": {"categories": ["flowers"], "min": 4, "max": 4},
+    }
+    _insert_rubric(bot, "flowers", config, rubric_id=1)
+    await bot.process_rubric_schedule(reference=datetime.utcnow())
+    row = bot.db.execute(
+        "SELECT name, status, payload FROM jobs_queue WHERE name='publish_rubric'"
+    ).fetchone()
+    assert row is not None
+    payload = json.loads(row["payload"])
+    assert payload["rubric_code"] == "flowers"
+    assert payload["channel_id"] == -100
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_publish_flowers_removes_assets(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+    config = {
+        "enabled": True,
+        "assets": {"categories": ["flowers"], "min": 4, "max": 6},
+    }
+    _insert_rubric(bot, "flowers", config, rubric_id=1)
+    now = datetime.utcnow().isoformat()
+    for idx in range(4):
+        metadata = {"file": {"file_id": f"file{idx}"}}
+        bot.data.save_asset(
+            -2000,
+            100 + idx,
+            None,
+            "",
+            metadata=metadata,
+            categories=["flowers"],
+            rubric_id=1,
+        )
+
+    calls = []
+
+    async def fake_api(method, data=None, *, files=None):
+        calls.append({"method": method, "data": data, "files": files})
+        return {"ok": True, "result": [{"message_id": 42}]}
+
+    bot.api_request = fake_api  # type: ignore
+    ok = await bot.publish_rubric("flowers", channel_id=-500)
+    assert ok
+    assert calls and calls[0]["method"] == "sendMediaGroup"
+    remaining = bot.db.execute("SELECT COUNT(*) FROM assets").fetchone()[0]
+    assert remaining == 0
+    history = bot.db.execute("SELECT metadata FROM posts_history").fetchone()
+    assert history is not None
+    meta = json.loads(history["metadata"])
+    assert meta["rubric_code"] == "flowers"
+    assert meta["asset_ids"]
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_publish_guess_arch_with_overlays(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+    storage = tmp_path / "storage"
+    storage.mkdir(parents=True, exist_ok=True)
+    bot.asset_storage = storage
+    config = {
+        "enabled": True,
+        "assets": {"categories": ["photo_weather"], "min": 3, "max": 3},
+        "weather_city": "Kaliningrad",
+    }
+    _insert_rubric(bot, "guess_arch", config, rubric_id=2)
+    bot.db.execute(
+        "INSERT OR IGNORE INTO cities (id, name, lat, lon) VALUES (1, 'Kaliningrad', 0, 0)"
+    )
+    bot.db.execute(
+        """
+        INSERT OR REPLACE INTO weather_cache_hour (city_id, timestamp, temperature, weather_code, wind_speed, is_day)
+        VALUES (1, ?, 12.5, 3, 5.4, 1)
+        """,
+        (datetime.utcnow().isoformat(),),
+    )
+    bot.db.commit()
+    assets = []
+    for idx in range(3):
+        image_path = tmp_path / f"asset_{idx}.jpg"
+        Image.new("RGB", (400, 300), color=(idx * 40, 10, 10)).save(image_path)
+        metadata = {
+            "file": {"file_id": f"gfile{idx}"},
+            "local_path": str(image_path),
+        }
+        asset_id = bot.data.save_asset(
+            -3000,
+            500 + idx,
+            None,
+            "",
+            metadata=metadata,
+            categories=["photo_weather"],
+            rubric_id=2,
+        )
+        assets.append(asset_id)
+
+    calls = []
+
+    async def fake_api(method, data=None, *, files=None):
+        calls.append({"method": method, "data": data, "files": files})
+        return {"ok": True, "result": [{"message_id": 99}]}
+
+    bot.api_request = fake_api  # type: ignore
+    ok = await bot.publish_rubric("guess_arch", channel_id=-777)
+    assert ok
+    assert calls and calls[0]["files"]
+    media_payload = calls[0]["data"]["media"]
+    assert len(media_payload) == 3
+    remaining = bot.db.execute("SELECT COUNT(*) FROM assets").fetchone()[0]
+    assert remaining == 0
+    history = bot.db.execute("SELECT metadata FROM posts_history").fetchone()
+    assert history is not None
+    meta = json.loads(history["metadata"])
+    assert meta["rubric_code"] == "guess_arch"
+    assert "weather" in meta
+    # ensure overlays cleaned up
+    numbered_exists = any(storage.glob("*_numbered_*.png"))
+    assert not numbered_exists
+    await bot.close()
+


### PR DESCRIPTION
## Summary
- add SQLite migration and data-access helpers to track rubric schedules and clean up consumed assets
- extend the bot with rubric job scheduling, OpenAI-powered copy generation, and publication flows for `flowers` and `guess_arch`
- support multipart Telegram uploads, overlay rendering, and add coverage for rubric scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb046ffe08332a758b50ab0169a35