### PR TITLE
Migrate legacy asset images into assets

### DIFF
--- a/migrations/0010_migrate_assets.sql
+++ b/migrations/0010_migrate_assets.sql
@@ -1,0 +1,102 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS asset_images (
+    message_id INTEGER PRIMARY KEY,
+    hashtags TEXT,
+    template TEXT,
+    used_at TEXT
+);
+
+WITH
+    channel AS (
+        SELECT channel_id
+        FROM asset_channel
+        ORDER BY rowid
+        LIMIT 1
+    ),
+    src AS (
+        SELECT
+            ai.message_id,
+            ai.template,
+            ai.hashtags,
+            TRIM(COALESCE(ai.hashtags, '')) AS cleaned
+        FROM asset_images ai
+    ),
+    tokens(message_id, rest, token, idx) AS (
+        SELECT
+            message_id,
+            CASE
+                WHEN cleaned = '' THEN ''
+                WHEN INSTR(cleaned, ' ') = 0 THEN ''
+                ELSE LTRIM(SUBSTR(cleaned, INSTR(cleaned || ' ', ' ')))
+            END AS rest,
+            CASE
+                WHEN cleaned = '' THEN NULL
+                WHEN INSTR(cleaned, ' ') = 0 THEN cleaned
+                ELSE SUBSTR(cleaned, 1, INSTR(cleaned || ' ', ' ') - 1)
+            END AS token,
+            0 AS idx
+        FROM src
+        UNION ALL
+        SELECT
+            message_id,
+            CASE
+                WHEN rest = '' THEN ''
+                WHEN INSTR(rest, ' ') = 0 THEN ''
+                ELSE LTRIM(SUBSTR(rest, INSTR(rest || ' ', ' ')))
+            END,
+            CASE
+                WHEN rest = '' THEN NULL
+                WHEN INSTR(rest, ' ') = 0 THEN rest
+                ELSE SUBSTR(rest, 1, INSTR(rest || ' ', ' ') - 1)
+            END,
+            idx + 1
+        FROM tokens
+        WHERE rest <> ''
+    ),
+    aggregated AS (
+        SELECT
+            message_id,
+            COALESCE(
+                (
+                    SELECT json_group_array(token)
+                    FROM (
+                        SELECT token
+                        FROM tokens t2
+                        WHERE t2.message_id = t.message_id
+                          AND t2.token IS NOT NULL
+                          AND t2.token <> ''
+                        ORDER BY t2.idx
+                    )
+                ),
+                json('[]')
+            ) AS categories
+        FROM tokens t
+        GROUP BY message_id
+    )
+INSERT INTO assets (
+    channel_id,
+    message_id,
+    caption_template,
+    hashtags,
+    categories,
+    created_at,
+    updated_at
+)
+SELECT
+    (SELECT channel_id FROM channel),
+    src.message_id,
+    src.template,
+    src.hashtags,
+    COALESCE(aggregated.categories, json('[]')),
+    datetime('now'),
+    datetime('now')
+FROM src
+LEFT JOIN aggregated USING (message_id)
+WHERE src.message_id IS NOT NULL
+  AND NOT EXISTS (
+        SELECT 1 FROM assets WHERE message_id = src.message_id
+    );
+
+DROP TABLE IF EXISTS asset_images;
+COMMIT;

--- a/tests/test_asset_migration.py
+++ b/tests/test_asset_migration.py
@@ -1,0 +1,90 @@
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from data_access import DataAccess
+from main import Bot, apply_migrations
+
+
+def _prepare_legacy_db(path: str, *, channel_id: int = 123, message_id: int = 456) -> None:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS asset_channel (
+            channel_id INTEGER PRIMARY KEY
+        );
+        DELETE FROM asset_channel;
+        INSERT INTO asset_channel (channel_id) VALUES ({channel});
+        CREATE TABLE IF NOT EXISTS asset_images (
+            message_id INTEGER PRIMARY KEY,
+            hashtags TEXT,
+            template TEXT,
+            used_at TEXT
+        );
+        DELETE FROM asset_images;
+        INSERT INTO asset_images (message_id, hashtags, template, used_at)
+        VALUES ({message}, '#sun #Cat', 'Legacy caption', NULL);
+        """.format(channel=channel_id, message=message_id)
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_sql_migration_transfers_legacy_assets(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    _prepare_legacy_db(str(db_path))
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    apply_migrations(conn)
+
+    data = DataAccess(conn)
+    asset = data.get_next_asset({"#sun"})
+
+    assert asset is not None
+    assert asset.message_id == 456
+    assert asset.channel_id == 123
+    assert set(asset.categories) == {"#sun", "#Cat"}
+    assert asset.caption_template == "Legacy caption"
+
+    table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='asset_images'"
+    ).fetchone()
+    assert table is None
+
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_bot_publish_weather_uses_migrated_legacy_assets(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    _prepare_legacy_db(str(db_path), channel_id=321, message_id=654)
+
+    bot = Bot("dummy", str(db_path))
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def dummy_request(method: str, data: dict | None = None):
+        calls.append((method, data))
+        if method == "copyMessage":
+            return {"ok": True, "result": {"message_id": 111}}
+        return {"ok": True}
+
+    bot.api_request = dummy_request  # type: ignore[assignment]
+
+    ok = await bot.publish_weather(999, {"#sun"})
+
+    assert ok is True
+    assert calls
+    method, payload = calls[0]
+    assert method == "copyMessage"
+    assert payload is not None
+    assert payload["from_chat_id"] == 321
+    assert payload["message_id"] == 654
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- migrate legacy `asset_images` rows into the `assets` table and drop the old storage
- run a runtime migration in the bot to backfill any remaining legacy rows
- add tests covering DataAccess selection and Bot publishing with migrated assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dfd64dc9e88332844f9bc86af7606e