### PR TITLE
Queue ingest job with metadata verification for new assets

### DIFF
--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -136,9 +136,11 @@ async def test_photo_triggers_ingest_and_vision(tmp_path, caplog):
     assert vision_rows
     vision_payload = json.loads(vision_rows[0]['payload'])
     assert vision_payload['asset_id'] == asset_id
-    ingest_log = any('Scheduled ingest job' in rec.message for rec in caplog.records)
+    ingest_messages = [rec.message for rec in caplog.records if 'Scheduled ingest job' in rec.message]
+    ingest_log = bool(ingest_messages)
     vision_log = any('queued for vision job' in rec.message for rec in caplog.records)
     assert ingest_log and vision_log
+    assert any('reason=new_message' in msg for msg in ingest_messages)
     await bot.close()
 
 


### PR DESCRIPTION
## Summary
- add a helper that looks up stored asset metadata before queueing the ingest job and re-use it for new messages and edits
- extend the ingest/vision integration test to assert the new log contains the enqueue reason so we know the chain runs on new photos

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e0c46e4ee48332886c43b61ccf4b9f