### PR TITLE
Refresh documentation for asset ingestion and rubrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,173 +1,92 @@
 # Telegram Scheduler Bot
 
-This bot allows authorized users to schedule posts to their Telegram channels.
-
-## Features
-- User authorization with superadmin.
-- Channel tracking where bot is admin.
-- Schedule message forwarding to one or more channels with inline interface. The bot forwards the original post so views and custom emoji are preserved. It must be a member of the source channel.
-- If forwarding fails (e.g., bot not in source), the message is copied instead.
-- View posting history.
-- User lists show clickable usernames for easy profile access.
-- Local timezone support for scheduling.
-- Configurable scheduler interval.
-- Add inline buttons to existing posts.
-- Remove inline buttons from existing posts.
-- Weather updates from Open-Meteo roughly every 30 minutes with the raw response logged. Admins
-  can view the latest data or force an update with `/weather now`. The `/weather` command lists
-  the cached weather and sea temperature for all registered locations.
-- Register channel posts with custom templates for automatic weather updates,
-  including sea temperature, working with both text and caption posts.
-- Daily weather posts use images from a dedicated private channel selected with
-  `/set_assets_channel`.
-
-- Forecast periods (morning/day/evening/night) are averaged from hourly data and
-  rounded to whole degrees for smoother values.
-
+## Summary
+- **Asset ingestion**. The bot listens to the configured assets channel, stores each message as an asset record and downloads the original media to local storage. Every photo must contain GPS EXIF data so the bot can resolve the city through Nominatim; authors without coordinates receive an automatic reminder.
+- **Recognition pipeline**. After ingestion the asynchronous job queue schedules a `vision` task that classifies the photo with OpenAI `gpt-4o-mini`, storing the rubric category, architectural details and detected flowers while respecting per-model daily token quotas configured via environment variables.
+- **Rubric automation**. Two daily rubrics are supported out of the box: `flowers` creates a carousel with greetings for cities detected in flower assets, while `guess_arch` prepares a numbered architecture quiz with optional overlays and weather context. Both rubrics consume recognized assets and clean them up after publishing.
+- **Admin workflow**. Superadmins manage user access, asset channel binding and rubric schedules directly inside Telegram via commands and inline buttons. The admin interface also exposes manual approval queues and quick status messages for rubric runs.
+- **Operations guardrails**. OpenAI usage is rate-limited per model, reverse geocoding calls Nominatim with throttling, and each rubric publication is persisted with metadata for auditing through the admin tools.
 
 ## Commands
-- /start - register or access bot
-- /pending - list pending users (admin)
-- /approve <id> - approve user
-- /reject <id> - reject user
-- /add_user <id> - manually add a user (superadmin)
-- /list_users - list approved users
-- /remove_user <id> - remove user
-- /channels - list channels (admin)
-- /scheduled - show scheduled posts with target channel names
-- /history - recent posts
-- /tz <offset> - set timezone offset (e.g., +02:00). Affects daily weather schedules immediately
-- /addbutton <post_url> <text> <url> - add inline button to existing post (button text may contain spaces)
-- /delbutton <post_url> - remove all buttons from an existing post and clear stored weather buttons
+### Access & governance
+- `/start` – registers the requester and assigns the first superadmin on first launch.
+- `/pending`, `/approve <id>`, `/reject <id>` – manage the onboarding queue from the Telegram admin interface.
+- `/add_user <id>`, `/remove_user <id>`, `/list_users` – grant or revoke long-term access to the scheduler and rubric tools.
 
-- /addcity <name> <lat> <lon> - add a city for weather checks (admin, coordinates
+### Asset management
+- `/set_assets_channel` – bind the private storage channel used for ASSETS ingestion; only posts created after this command are captured.
+- `/history` and `/scheduled` – inspect previously published posts and queued schedules, including rubric drops copied from the assets channel.
 
-  may include six or more decimal places and may be separated with a comma)
-- /addsea <name> <lat> <lon> - add a sea location for water temperature checks
-  (comma separator allowed)
-
-- /cities - list cities with inline delete buttons (admin). Coordinates are shown
-  with six decimal places.
-- /seas - list sea locations with inline delete buttons (admin).
-- /weather [now] - show cached weather; append `now` to refresh data
-- /regweather <post_url> <template> - register a post for weather updates
-
- - /addweatherbutton <post_url> <text> [url] - attach a button linking to the latest forecast. Text supports the same placeholders as templates. Multiple weather buttons share one row
-
-- /weatherposts [update] - list registered weather posts with a 'Stop weather' button on each; append `update` to refresh
-- /setup_weather - interactive wizard to add a daily forecast channel
-- /list_weather_channels - show configured weather channels with action buttons
-- /set_assets_channel - choose the channel used for weather assets
-
-
-`/list_weather_channels` displays the last publication time adjusted to your
-current `/tz` setting. When using the "Run now" button, the bot attempts to copy
-the next available asset. The run is not recorded, so the regular scheduled post
-for that day will still happen. If no unused asset exists, it replies with
-
-"No asset to publish".
-
-### Asset channel
-Images and caption templates are stored in a private channel
-`@kotopogoda_assets`. Choose this channel with `/set_assets_channel` **before**
-uploading assets. Only posts sent after the bot becomes an admin are captured.
-
-If you edit a post in this channel, the bot updates the stored template.
-Used posts are deleted automatically after publishing so the channel always
-contains only fresh assets.
-
-
-
+### Rubrics & quotas
+- `/list_weather_channels` – repurposed admin dashboard that now shows rubric schedules, remaining OpenAI daily quota and lets admins toggle individual runs (messages labelled accordingly).
+- `/weather now` – forces a refresh of cached weather that is embedded into the `guess_arch` rubric intro; other weather commands remain available under Legacy behavior.
+- Inline buttons labelled «Run now» next to rubric schedules enqueue an immediate `publish_rubric` job using the background queue while preserving the regular cadence.
 
 ## User Stories
-
-### Done
-- **US-1**: Registration of the first superadmin.
-- **US-2**: User registration queue with limits and admin approval flow.
-- **US-3**: Superadmin manages pending and approved users. Rejected users cannot
-  register again. Pending and approved lists display clickable usernames with
-  inline approval buttons.
-- **US-4**: Channel listener events and `/channels` command.
-- **US-5**: Post scheduling interface with channel selection, cancellation and rescheduling. Scheduled list shows the post preview or link along with the target channel name and time in HH:MM DD.MM.YYYY format.
-- **US-6**: Scheduler forwards queued posts at the correct local time. If forwarding fails because the bot is not a member, it falls back to copying. Interval is configurable and all actions are logged.
-- **US-8**: `/addbutton <post_url> <text> <url>` adds an inline button to an existing channel post. Update logged with INFO level.
-- **US-8.1**: `/addbutton` appends a new button without removing existing ones.
-
-- **US-9**: `/delbutton <post_url>` removes all inline buttons from an existing channel post and deletes stored weather button data.
-
-- **US-10**: Admin adds a city with `/addcity`.
-- **US-11**: Admin views and removes cities with `/cities`.
-- **US-12**: Periodic weather collection from Open-Meteo with up to three retries on failure.
-- **US-13**: Admin requests last weather check info and can force an update.
-- **US-14**: Admin registers a weather post for updates, including sea temperature.
-
- - **US-14.1**: `/addweatherbutton <post_url> <text> [url]` attaches a button linking to the latest `#котопогода`. Multiple weather buttons are placed on one row. `/weatherposts` lists these posts with a remove option.
-
-- **US-15**: Automatic weather post updates with current weather and sea temperature.
-- **US-16**: Admin lists registered posts showing the rendered weather and sea data for all registered seas.
-- **US-16.1**: Admin stops weather updates for a post using the "Stop weather" button shown in `/weatherposts`.
-- **US-17**: Admin adds a channel for daily weather posts and specifies the publication time with `/setup_weather`.
-- **US-18**: Content manager uploads images with templates to `@kotopogoda_assets`; used posts disappear after publishing.
-- **US-19**: Admin views the list of weather channels and can send a post immediately with «Run now» or remove a channel with «Stop».
-- **US-20**: The bot publishes the weather once per day for each configured channel at the set time.
-
-
-
-
-### In Progress
-- **US-7**: Logging of all operations.
+### Implemented
+- **US-1**: As a photographer I can drop photos into the ASSETS channel and the bot ingests them with EXIF validation, notifying me if coordinates are missing so the rubric team always knows the shooting location.
+- **US-2**: As a curator I can rely on automatic recognition to pre-fill categories, architecture notes and flower types for every asset, reducing manual tagging before rubric publication.
+- **US-3**: As a rubric editor I can configure daily schedules for `flowers` and `guess_arch`, ensure enough classified assets are available and publish them automatically or on demand from Telegram.
+- **US-4**: As an administrator I can monitor OpenAI token consumption, review rubric history and audit which assets were consumed, all through the bot’s inline admin interface.
+- **US-5**: As an operations engineer I have a persistent job queue with retry/backoff semantics and manual controls so rubric jobs can be re-run safely without duplicate posts.
 
 ### Planned
+- Automatic triage for non-photo assets and support for additional rubrics once the asset taxonomy is expanded.
+
+## Environment Setup
+### Required environment variables
+- `TELEGRAM_BOT_TOKEN` – Telegram bot API token used for both webhook registration and admin interactions.
+- `WEBHOOK_URL` – public HTTPS base used to register `/webhook` on startup.
+- `DB_PATH` – path to the SQLite database (default `/data/bot.db`).
+- `ASSET_STORAGE_DIR` – optional override for local media storage. Defaults to `/tmp/bot_assets`; ensure the directory persists across deployments if you expect re-ingestion safeguards.
+- `TZ_OFFSET` – default timezone applied to schedules until users pick their own offset.
+- `SCHED_INTERVAL_SEC` – polling cadence for the scheduler loop (default `30`).
+- `OPENAI_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
+- `OPENAI_DAILY_TOKEN_LIMIT`, `OPENAI_DAILY_TOKEN_LIMIT_4O`, `OPENAI_DAILY_TOKEN_LIMIT_4O_MINI` – optional per-model quotas that gate new OpenAI jobs until the next UTC reset.
+
+### External services
+- **Nominatim** – the bot queries `https://nominatim.openstreetmap.org/reverse` and rate-limits calls to one request per second. Set `User-Agent` friendly values in the code if you fork, and consider running your own Nominatim instance for higher throughput.
+- **OpenAI Responses API** – outbound requests target the `/responses` endpoint; ensure outbound egress is permitted from your hosting environment.
+
+### Local assets & overlays
+- Store overlay PNGs for the `guess_arch` rubric inside the directory referenced by the rubric config (default `main.py` → `overlays`). Files named `1.png`, `2.png`, etc., are overlaid on published photos; the bot auto-generates numeric badges when files are missing.
+- Persist asset storage on a volume so ingestion and recognition jobs can retry without re-downloading media. Temporary directories will break overlay generation and duplicate detection after restarts.
+
+## Job Queue and Manual Rubrics
+- The SQLite-backed job queue starts automatically when the bot boots, loads due jobs every second and executes handlers concurrently according to `JobQueue(concurrency=...)` settings. Failed jobs retry with exponential backoff up to five attempts before being marked as `failed`. Inspect `jobs_queue` via any SQLite tool for troubleshooting.
+- To enqueue a rubric manually without waiting for the scheduler, run the following snippet with valid environment variables:
+  ```bash
+  python - <<'PY'
+  import asyncio, os
+  from main import Bot
+
+  async def trigger():
+      bot = Bot(os.environ["TELEGRAM_BOT_TOKEN"], os.environ.get("DB_PATH", "/data/bot.db"))
+      await bot.start()
+      # replace channel id with the target Telegram channel id
+      await bot.enqueue_rubric("flowers", channel_id=-1001234567890)
+      await bot.close()
+
+  asyncio.run(trigger())
+  PY
+  ```
+  Replace `flowers` with `guess_arch` as needed. The job queue deduplicates identical pending payloads, so repeated runs are safe.
+- For ad-hoc publication bypassing the queue entirely, call `publish_rubric` inside the same context; it returns `True` on success and records the run in `posts_history` for later review.
 
 ## Deployment
-The bot is designed for Fly.io using a webhook on `/webhook` and listens on port `8080`.
-For Telegram to reach the webhook over HTTPS, the Fly.io service must expose port `443` with TLS termination enabled. This is configured in `fly.toml`.
+The bot targets Fly.io and exposes a single aiohttp application on port `8080`. Ensure your Fly.io service terminates TLS on port `443` and forwards traffic to the container port so Telegram can reach the webhook. The provided `fly.toml` already contains the required configuration.
 
-### Environment Variables
-- `TELEGRAM_BOT_TOKEN` – Telegram bot API token.
-
-- `WEBHOOK_URL` – external HTTPS URL of the deployed application. Used to register the Telegram webhook.
-
-- `DB_PATH` – path to the SQLite database (default `bot.db`).
-- `FLY_API_TOKEN` – token for automated Fly deployments.
-- `TZ_OFFSET` – default timezone offset like `+02:00`.
-- `SCHED_INTERVAL_SEC` – scheduler check interval in seconds (default `30`).
-
-### Запуск локально
+### Local run
 1. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Запустите бота:
+2. Launch the bot:
    ```bash
    python main.py
    ```
 
-> Fly.io secrets `TELEGRAM_BOT_TOKEN` и `FLY_API_TOKEN` должны быть заданы перед запуском.
+Provision Fly.io secrets (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_URL`, `OPENAI_API_KEY`, token limits) before the first deployment.
 
-
-### Деплой на Fly.io
-
-1. Запустить приложение в первый раз (из CLI, однократно):
-
-```bash
-fly launch
-fly volumes create sched_db --size 1
-
-
-```
-
-2. После этого любой push в ветку `main` будет автоматически триггерить деплой.
-
-3. Все секреты устанавливаются через Fly.io UI или CLI:
-
-```bash
-fly secrets set TELEGRAM_BOT_TOKEN=xxx
-fly secrets set WEBHOOK_URL=https://<app-name>.fly.dev/
-```
-
-The `fly.toml` file should expose port `443` so that Telegram can connect over HTTPS.
-
-## CI/CD
-Каждый push в main запускает GitHub Actions → flyctl deploy → Fly.io.
-
+## Legacy
+Historical documentation for the weather scheduler, including sea temperature handling and template placeholders, now lives in `docs/weather.md`. Those features remain in the codebase for backward compatibility but are no longer part of the primary rubric workflow.


### PR DESCRIPTION
## Summary
- rewrite the README to describe the asset ingestion and recognition pipeline, daily rubrics, and updated admin workflows
- add detailed environment, queue, and manual rubric execution guidance alongside a Legacy section for weather scheduling
- align the architectural overview with the new asset- and rubric-focused design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d197e34083328ca02a8e9cb9c17b