### PR TITLE
Add changelog and document recognition release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.0] - 2024-05-17
+### Added
+- Automatic recognition pipeline that classifies ingested assets with OpenAI `gpt-4o-mini`, stores architectural metadata and detects flowers for downstream rubrics.
+- Persistent asynchronous job queue that schedules recognition, rubric publication and manual overrides with retry/backoff semantics.
+- Daily rubrics «Цветы» and «Угадай» that assemble carousels and quizzes from recognized assets and clean up consumed media.
+- Token accounting with per-model daily quotas to prevent OpenAI overages and surface usage to administrators.
+- New database migrations (`0008_vision_enhancements.sql`, `0009_token_usage.sql`, `0012_core_schema.sql`) required to support recognition storage, queue persistence, rubric history and token usage tracking; apply them before deploying this release.
+
+## [1.2.0] - 2024-04-02
+### Added
+- Initial public release with Telegram ingestion, weather automation and manual rubric tooling.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Telegram Scheduler Bot
 
 ## Summary
+[Полную историю изменений см. в `CHANGELOG.md`](CHANGELOG.md).
+
 - **Asset ingestion**. The bot listens to the configured assets channel, stores each message as an asset record and downloads the original media to local storage. Every photo must contain GPS EXIF data so the bot can resolve the city through Nominatim; authors without coordinates receive an automatic reminder.
 - **Recognition pipeline**. After ingestion the asynchronous job queue schedules a `vision` task that classifies the photo with OpenAI `gpt-4o-mini`, storing the rubric category, architectural details and detected flowers while respecting per-model daily token quotas configured via environment variables.
 - **Rubric automation**. Two daily rubrics are supported out of the box: `flowers` creates a carousel with greetings for cities detected in flower assets, while `guess_arch` prepares a numbered architecture quiz with optional overlays and weather context. Both rubrics consume recognized assets and clean them up after publishing.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -2,6 +2,8 @@
 
 This document describes the weather feature set for the Telegram scheduler bot.
 
+For an overview of project-level releases and database requirements, refer to the [CHANGELOG](../CHANGELOG.md).
+
 Weather for each city is queried from the Open-Meteo API approximately every 30
 minutes and stored in the `weather_cache` table. The bot logs both the raw HTTP
 response and the parsed weather information. The request looks like:


### PR DESCRIPTION
## Summary
- add a Keep a Changelog formatted CHANGELOG with the 1.3.0 release covering recognition, rubrics, token quotas and required migrations
- document the initial 1.2.0 release for historical context
- link the README and weather documentation to the changelog for release history visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f1852e648332a2e566ed124f86c1