### PR TITLE
Respect timezone when enforcing OpenAI usage limits

### DIFF
--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -56,6 +56,7 @@ async def test_rubric_scheduler_enqueues_jobs(tmp_path):
     payload = json.loads(row["payload"])
     assert payload["rubric_code"] == "flowers"
     assert payload["channel_id"] == -100
+    assert payload["tz_offset"] == "+00:00"
     await bot.close()
 
 
@@ -82,6 +83,7 @@ async def test_rubric_scheduler_respects_timezone(tmp_path):
     assert payload["rubric_code"] == "guess_arch"
     assert payload["channel_id"] == -900
     assert payload["scheduled_at"] == expected.isoformat()
+    assert payload["tz_offset"] == "+03:00"
     await bot.close()
 
 
@@ -104,6 +106,7 @@ async def test_enqueue_rubric_manual_and_test_channels(tmp_path):
     assert payload["schedule_key"] == "manual"
     assert payload["channel_id"] == -111
     assert not payload.get("test")
+    assert payload["tz_offset"] == "+00:00"
     assert row["status"] == "queued"
 
     test_job_id = bot.enqueue_rubric("flowers", test=True)
@@ -115,6 +118,7 @@ async def test_enqueue_rubric_manual_and_test_channels(tmp_path):
     assert test_payload["schedule_key"] == "manual-test"
     assert test_payload["channel_id"] == -222
     assert test_payload["test"] is True
+    assert test_payload["tz_offset"] == "+00:00"
     assert test_row["status"] == "queued"
     await bot.close()
 

--- a/tests/test_token_limits.py
+++ b/tests/test_token_limits.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from datetime import datetime, date, timezone
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from main import Bot  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_next_usage_reset_uses_local_midnight(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+    reference = datetime(2024, 6, 1, 20, 0, 0)
+    tz_offset = "+03:00"
+    reset = bot._next_usage_reset(now=reference, tz_offset=tz_offset)  # type: ignore[attr-defined]
+    assert reset == datetime(2024, 6, 1, 21, 5)
+    local_reset = reset.replace(tzinfo=timezone.utc).astimezone(  # type: ignore[attr-defined]
+        bot._parse_tz_offset(tz_offset)  # type: ignore[attr-defined]
+    )
+    assert local_reset.hour == 0
+    assert local_reset.minute == 5
+    assert local_reset.date() == date(2024, 6, 2)
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_token_usage_total_respects_timezone(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+    entries = [
+        ("2024-06-01T20:59:59", 5),
+        ("2024-06-01T21:00:00", 7),
+        ("2024-06-02T20:59:59", 11),
+        ("2024-06-02T21:00:00", 13),
+    ]
+    for ts, total in entries:
+        bot.data.log_token_usage(
+            "gpt-4o",
+            total,
+            None,
+            total,
+            timestamp=ts,
+        )
+    total = bot.data.get_daily_token_usage_total(
+        day=date(2024, 6, 2), models={"gpt-4o"}, tz_offset="+03:00"
+    )
+    assert total == 18
+    # Default timezone fallback should use global TZ_OFFSET when tz is None
+    default_total = bot.data.get_daily_token_usage_total(models={"gpt-4o"})
+    assert isinstance(default_total, int)
+    await bot.close()


### PR DESCRIPTION
## Summary
- include tz_offset values in vision and rubric job payloads so OpenAI usage limits can respect each schedule's timezone
- compute daily token usage within timezone-adjusted windows and log local resume timestamps when limits are exceeded
- cover the new behaviour with pytest cases that assert scheduler payloads and reset calculations honour local midnight

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0fe92013483328c3dd7125a50b180