### PR TITLE
Skip ingest for recognized message edits

### DIFF
--- a/data_access.py
+++ b/data_access.py
@@ -396,7 +396,11 @@ class DataAccess:
             (tg_chat_id, message_id),
         )
 
-    def is_recognized_message(self, tg_chat_id: int, message_id: int) -> bool:
+    def is_recognized_message(self, tg_chat_id: int | None, message_id: int | None) -> bool:
+        """Check if the pair matches a previously recognized asset message."""
+
+        if not tg_chat_id or not message_id:
+            return False
         row = self.conn.execute(
             "SELECT 1 FROM assets WHERE tg_chat_id=? AND recognized_message_id=? LIMIT 1",
             (tg_chat_id, message_id),

--- a/main.py
+++ b/main.py
@@ -445,8 +445,8 @@ class Bot:
         if self.asset_channel_id and message.get('chat', {}).get('id') == self.asset_channel_id:
             info = self._collect_asset_metadata(message)
             message_id = info.get("message_id")
-            tg_chat_id = info.get("tg_chat_id") or 0
-            if not message_id:
+            tg_chat_id = info.get("tg_chat_id")
+            if not message_id or not tg_chat_id:
                 return
             if self.data.is_recognized_message(tg_chat_id, message_id):
                 logging.info(

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -367,6 +367,161 @@ async def test_recognized_message_skips_reingest(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_recognized_edit_skips_reingest(tmp_path):
+    bot = Bot('test-token', str(tmp_path / 'db.sqlite'))
+    bot.set_asset_channel(-100123)
+
+    img = Image.new('RGB', (10, 10), color='white')
+    buffer = BytesIO()
+    img.save(buffer, format='JPEG')
+    image_bytes = buffer.getvalue()
+
+    recognized_mid = 777
+
+    async def fake_download(file_id):  # type: ignore[override]
+        return image_bytes
+
+    async def fake_api_request(method, data=None, *, files=None):  # type: ignore[override]
+        if method == 'sendPhoto':
+            return {'ok': True, 'result': {'message_id': recognized_mid}}
+        return {'ok': True, 'result': {}}
+
+    class DummyOpenAI:
+        def __init__(self):
+            self.api_key = 'test-key'
+
+        async def classify_image(self, **kwargs):
+            return OpenAIResponse(
+                {
+                    'category': 'кот',
+                    'arch_view': '',
+                    'photo_weather': 'солнечно',
+                    'flower_varieties': [],
+                    'confidence': 0.9,
+                },
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                request_id='req-1',
+            )
+
+    bot._download_file = fake_download  # type: ignore[assignment]
+    bot.api_request = fake_api_request  # type: ignore[assignment]
+    bot.openai = DummyOpenAI()
+
+    message = {
+        'message_id': 99,
+        'date': int(datetime.utcnow().timestamp()),
+        'chat': {'id': -100123},
+        'caption': '#котопогода исходник',
+        'photo': [
+            {
+                'file_id': 'ph_small',
+                'file_unique_id': 'uniq_small',
+                'file_size': 10,
+                'width': 320,
+                'height': 200,
+            },
+            {
+                'file_id': 'ph_large',
+                'file_unique_id': 'uniq_large',
+                'file_size': 30,
+                'width': 1920,
+                'height': 1080,
+            },
+        ],
+    }
+
+    await bot.handle_message(message)
+
+    ingest_row = bot.db.execute(
+        "SELECT * FROM jobs_queue WHERE name='ingest' ORDER BY id LIMIT 1"
+    ).fetchone()
+    assert ingest_row is not None
+    ingest_payload = json.loads(ingest_row['payload']) if ingest_row['payload'] else {}
+    ingest_job = Job(
+        id=ingest_row['id'],
+        name=ingest_row['name'],
+        payload=ingest_payload,
+        status=ingest_row['status'],
+        attempts=ingest_row['attempts'],
+        available_at=datetime.fromisoformat(ingest_row['available_at'])
+        if ingest_row['available_at']
+        else None,
+        last_error=ingest_row['last_error'],
+        created_at=datetime.fromisoformat(ingest_row['created_at']),
+        updated_at=datetime.fromisoformat(ingest_row['updated_at']),
+    )
+
+    await bot._job_ingest(ingest_job)
+
+    vision_row = bot.db.execute(
+        "SELECT * FROM jobs_queue WHERE name='vision' ORDER BY id LIMIT 1"
+    ).fetchone()
+    assert vision_row is not None
+    vision_payload = json.loads(vision_row['payload']) if vision_row['payload'] else {}
+    vision_job = Job(
+        id=vision_row['id'],
+        name=vision_row['name'],
+        payload=vision_payload,
+        status=vision_row['status'],
+        attempts=vision_row['attempts'],
+        available_at=datetime.fromisoformat(vision_row['available_at'])
+        if vision_row['available_at']
+        else None,
+        last_error=vision_row['last_error'],
+        created_at=datetime.fromisoformat(vision_row['created_at']),
+        updated_at=datetime.fromisoformat(vision_row['updated_at']),
+    )
+
+    await bot._job_vision(vision_job)
+
+    asset_id = ingest_payload['asset_id']
+    asset = bot.data.get_asset(asset_id)
+    assert asset is not None
+    assert asset.recognized_message_id == recognized_mid
+
+    bot.db.execute('DELETE FROM jobs_queue')
+    bot.db.commit()
+
+    asset_count = bot.db.execute('SELECT COUNT(*) FROM assets').fetchone()[0]
+
+    edited_message = {
+        'message_id': recognized_mid,
+        'date': int(datetime.utcnow().timestamp()),
+        'chat': {'id': -100123},
+        'caption': 'Распознано: кот (ред.)',
+        'photo': [
+            {
+                'file_id': 'vision_small',
+                'file_unique_id': 'vision_small_unique',
+                'file_size': 12,
+                'width': 320,
+                'height': 200,
+            },
+            {
+                'file_id': 'vision_large',
+                'file_unique_id': 'vision_large_unique',
+                'file_size': 34,
+                'width': 1920,
+                'height': 1080,
+            },
+        ],
+    }
+
+    await bot.handle_edited_message(edited_message)
+
+    ingest_jobs = bot.db.execute(
+        "SELECT COUNT(*) FROM jobs_queue WHERE name='ingest'"
+    ).fetchone()[0]
+    assert ingest_jobs == 0
+    asset_count_after = bot.db.execute('SELECT COUNT(*) FROM assets').fetchone()[0]
+    assert asset_count_after == asset_count
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
 
 async def test_template_russian_and_period(tmp_path):
     bot = Bot('dummy', str(tmp_path / 'db.sqlite'))


### PR DESCRIPTION
## Summary
- prevent recognized message edits from re-triggering ingest jobs
- harden the recognized message lookup in the data access layer
- add a regression test covering recognized edit updates

## Testing
- pytest tests/test_weather_new.py::test_recognized_edit_skips_reingest -q

------
https://chatgpt.com/codex/tasks/task_e_68e10611d3708332acff9803c4f5fcbd