### PR TITLE
Document PORT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - `ASSET_STORAGE_DIR` – optional override for local media storage. Defaults to `/tmp/bot_assets`; ensure the directory persists across deployments if you expect re-ingestion safeguards.
 - `TZ_OFFSET` – default timezone applied to schedules until users pick their own offset.
 - `SCHED_INTERVAL_SEC` – polling cadence for the scheduler loop (default `30`).
+- `PORT` – aiohttp listener used when calling `web.run_app`; defaults to `8080` and must align with the port exposed by your hosting provider.
 - `OPENAI_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
 - `OPENAI_DAILY_TOKEN_LIMIT`, `OPENAI_DAILY_TOKEN_LIMIT_4O`, `OPENAI_DAILY_TOKEN_LIMIT_4O_MINI` – optional per-model quotas that gate new OpenAI jobs until the next UTC reset.
 


### PR DESCRIPTION
## Summary
- document the PORT environment variable in the README with its default and how aiohttp uses it when launching the app

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10f00443c8332a6ff38b3e15d6ede