### PR TITLE
Separate weather storage and recognition channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `/help` command that delivers a Markdown help guide with links to admin-interface workflows and manual button instructions.
+- Dual asset channel support with new `/set_weather_assets_channel` and `/set_recognition_channel` commands plus migration `0014_split_asset_channels.sql` that creates the recognition table and marks asset origins.
+- Regression coverage that simulates both channels to ensure weather posts ignore recognition-only assets.
+
+### Changed
+- `/set_assets_channel` now updates both channel roles for backward compatibility, while `publish_weather` only copies from the weather storage channel and leaves source messages untouched.
 
 ## [1.3.0] - 2024-05-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Summary
 [Полную историю изменений см. в `CHANGELOG.md`](CHANGELOG.md).
 
-- **Asset ingestion**. The bot listens to the configured assets channel, stores each message as an asset record and downloads the original media to local storage. Every photo must contain GPS EXIF data so the bot can resolve the city through Nominatim; authors without coordinates receive an automatic reminder.
+- **Asset ingestion**. The bot listens to the dedicated recognition channel for new submissions while weather-ready assets live in a separate storage channel. Every photo must contain GPS EXIF data so the bot can resolve the city through Nominatim; authors without coordinates receive an automatic reminder.
 - **Recognition pipeline**. After ingestion the asynchronous job queue schedules a `vision` task that classifies the photo with OpenAI `gpt-4o-mini`, storing the rubric category, architectural details and detected flowers while respecting per-model daily token quotas configured via environment variables.
 - **Rubric automation**. Two daily rubrics are supported out of the box: `flowers` creates a carousel with greetings for cities detected in flower assets, while `guess_arch` prepares a numbered architecture quiz with optional overlays and weather context. Both rubrics consume recognized assets and clean them up after publishing.
 - **Admin workflow**. Superadmins manage user access, asset channel binding and rubric schedules directly inside Telegram via commands and inline buttons. The admin interface also exposes manual approval queues and quick status messages for rubric runs.
@@ -21,7 +21,9 @@
 
 ### Channels & scheduling
 - `/channels` – print every channel known to the bot so superadmins can audit bindings.
-- `/set_assets_channel` – bind the private storage channel used for ASSETS ingestion; only posts created after this command are captured.
+- `/set_weather_assets_channel` – bind the private storage channel whose posts are copied by the weather scheduler.
+- `/set_recognition_channel` – pick the recognition/ingestion channel whose uploads trigger EXIF checks and vision jobs.
+- `/set_assets_channel` – legacy shortcut that assigns the same channel to both roles for backward compatibility.
 - `/setup_weather` – wizard that assigns rubric schedules to channels when new destinations are added.
 - `/list_weather_channels` – admin dashboard showing rubric schedules, last run timestamps and inline `Run now`/`Stop` actions.
 - `/history` and `/scheduled` – inspect previously published posts and queued schedules, including rubric drops copied from the assets channel (each scheduled item comes with inline `Cancel`/`Reschedule` controls).
@@ -38,6 +40,9 @@
 - `/addcity <name> <lat> <lon>`, `/cities` – manage the city directory used by the weather cache.
 - `/addsea <name> <lat> <lon>`, `/seas` – maintain the sea catalogue that powers shoreline forecasts.
 - `/amber` – open the inline picker for the Янтарный канал, then drill down to channel-specific toggles.
+
+### Channel configuration & migration
+- Upgrading from previous releases automatically copies the legacy assets channel into both the weather storage and recognition tables, so existing setups continue to work. Once the bot is updated you can run `/set_weather_assets_channel` and `/set_recognition_channel` to decouple the roles. Use `/set_assets_channel` if you prefer to keep a single shared channel.
 
 ## User Stories
 ### Implemented

--- a/migrations/0014_split_asset_channels.sql
+++ b/migrations/0014_split_asset_channels.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE assets ADD COLUMN origin TEXT NOT NULL DEFAULT 'weather';
+
+CREATE TABLE IF NOT EXISTS recognition_channel (
+    channel_id INTEGER PRIMARY KEY
+);
+
+INSERT OR IGNORE INTO recognition_channel (channel_id)
+SELECT channel_id FROM asset_channel LIMIT 1;
+
+COMMIT;

--- a/tests/test_manual_schedule.py
+++ b/tests/test_manual_schedule.py
@@ -11,7 +11,7 @@ os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'dummy')
 @pytest.mark.asyncio
 async def test_manual_run_does_not_block_schedule(tmp_path):
     bot = Bot('dummy', str(tmp_path / 'db.sqlite'))
-    bot.set_asset_channel(-100)
+    bot.set_weather_assets_channel(-100)
     calls = []
 
     async def dummy(method, data=None):

--- a/tests/test_vision_results.py
+++ b/tests/test_vision_results.py
@@ -8,8 +8,12 @@ from data_access import DataAccess
 
 
 def _load_schema(conn: sqlite3.Connection) -> None:
+    asset_channel_path = Path(__file__).resolve().parents[1] / "migrations" / "0004_asset_channel.sql"
+    conn.executescript(asset_channel_path.read_text(encoding="utf-8"))
     schema_path = Path(__file__).resolve().parents[1] / "migrations" / "0012_core_schema.sql"
     conn.executescript(schema_path.read_text(encoding="utf-8"))
+    upgrade_path = Path(__file__).resolve().parents[1] / "migrations" / "0014_split_asset_channels.sql"
+    conn.executescript(upgrade_path.read_text(encoding="utf-8"))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add a migration that introduces a recognition channel table and an origin flag for assets
- update bot command handling and ingestion so weather and recognition channels have independent flows
- refresh documentation and tests, including a regression that keeps recognition posts out of weather publishing

## Testing
- pytest -q --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68e11b3af8688332bb5ebd876acf88d2