### PR TITLE
Adjust guess_arch overlay sizing to 10–16% of the shorter side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `/set_assets_channel` now updates both channel roles for backward compatibility, while `publish_weather` only copies from the weather storage channel and leaves source messages untouched.
+- `guess_arch` overlays now scale to 10–16% of the shortest image side so custom PNG badges stay proportional across photo sizes.
 
 ## [1.3.0] - 2024-05-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 
 ### Local assets & overlays
 - Store overlay PNGs for the `guess_arch` rubric inside the directory referenced by the rubric config (default `main.py` → `overlays`). Files named `1.png`, `2.png`, etc., are overlaid on published photos; the bot auto-generates numeric badges when files are missing.
+- Keep badge graphics roughly within 10–16% of the shorter photo side. The bot rescales custom overlays into this window before compositing so numbers stay legible without hiding too much of the picture.
 - Persist asset storage on a volume so ingestion and recognition jobs can retry without re-downloading media. Temporary directories will break overlay generation and duplicate detection after restarts.
 
 ## Job Queue and Manual Rubrics

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import contextlib
 import io
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -5279,7 +5280,11 @@ class Bot:
                 overlay_img = overlay_src.convert("RGBA").copy()
         else:
             overlay_img = self._create_number_overlay(number, min(base_size))
-        max_side = max(96, min(base_size) // 4)
+        min_side = min(base_size)
+        min_target = max(1, math.ceil(min_side * 0.10))
+        max_target = max(min_target, math.floor(min_side * 0.16))
+        target = round(min_side * 0.12)
+        max_side = max(min_target, min(target, max_target))
         overlay_img = overlay_img.resize((max_side, max_side), Image.LANCZOS)
         return overlay_img
 

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -601,3 +601,26 @@ async def test_rubric_channel_and_schedule_edit_flow(tmp_path):
 
     await bot.close()
 
+
+@pytest.mark.asyncio
+async def test_overlay_size_stays_within_expected_ratio(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    custom_overlay_path = tmp_path / "custom_overlay.png"
+    Image.new("RGBA", (640, 320), (255, 0, 0, 255)).save(custom_overlay_path)
+
+    cases = [
+        (custom_overlay_path, (1600, 1200)),
+        (tmp_path / "missing_overlay.png", (600, 900)),
+        (tmp_path / "missing_overlay.png", (240, 960)),
+    ]
+
+    for overlay_path, base_size in cases:
+        overlay = bot._load_overlay_image(overlay_path, 1, base_size)
+        min_side = min(base_size)
+        ratio = overlay.width / min_side
+        assert overlay.size[0] == overlay.size[1]
+        assert 0.10 <= ratio <= 0.16
+
+    await bot.close()
+


### PR DESCRIPTION
## Summary
- clamp generated overlays so the final badge edge stays between 10% and 16% of the shortest photo side
- document the recommended badge proportions for rubric contributors and log the change in the changelog
- cover the new behaviour with a regression test for several base image sizes

## Testing
- pytest tests/test_rubrics.py::test_overlay_size_stays_within_expected_ratio

------
https://chatgpt.com/codex/tasks/task_e_68e16be383a083328ff2180faa6c6b0a