### PR TITLE
Add Supabase token usage mirroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Supabase integration that mirrors OpenAI token usage into `token_usage` via `SUPABASE_URL`/`SUPABASE_KEY`, including job metadata for downstream analytics.
 - `/help` command that delivers a Markdown help guide with links to admin-interface workflows and manual button instructions.
 - Dual asset channel support with new `/set_weather_assets_channel` and `/set_recognition_channel` commands plus migration `0014_split_asset_channels.sql` that creates the recognition table and marks asset origins.
 - Regression coverage that simulates both channels to ensure weather posts ignore recognition-only assets.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@
 - `OPENAI_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
 - `OPENAI_DAILY_TOKEN_LIMIT`, `OPENAI_DAILY_TOKEN_LIMIT_4O`, `OPENAI_DAILY_TOKEN_LIMIT_4O_MINI` – optional per-model quotas that gate new OpenAI jobs until the next UTC reset.
 - `PORT` – HTTP port that `web.run_app` listens on (default `8080`). Ensure it matches the port exposed by your proxy or hosting platform (Fly.io, Docker, etc.) so inbound requests reach the app.
+- `SUPABASE_URL`, `SUPABASE_KEY` – optional credentials for the Supabase project that receives OpenAI token usage events. When configured the bot mirrors SQLite usage rows into the `token_usage` table for centralized analytics.
 
 ### External services
 - **Nominatim** – the bot queries `https://nominatim.openstreetmap.org/reverse` and rate-limits calls to one request per second. Set `User-Agent` friendly values in the code if you fork, and consider running your own Nominatim instance for higher throughput.
 - **OpenAI Responses API** – outbound requests target the `/responses` endpoint; ensure outbound egress is permitted from your hosting environment.
+- **Supabase REST** – if `SUPABASE_URL`/`SUPABASE_KEY` are set, the bot posts token usage metrics to `rest/v1/token_usage` using the Supabase service role key.
 
 ### Local assets & overlays
 - Store overlay PNGs for the `guess_arch` rubric inside the directory referenced by the rubric config (default `main.py` → `overlays`). Files named `1.png`, `2.png`, etc., are overlaid on published photos; the bot auto-generates numeric badges when files are missing.

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+def _json_default(value: Any) -> Any:
+    """Fallback serializer that keeps non-JSON objects readable."""
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _normalize_meta(meta: Any) -> Any:
+    if meta is None:
+        return None
+    try:
+        serialized = json.dumps(meta, default=_json_default)
+    except TypeError:
+        serialized = json.dumps(str(meta))
+    return json.loads(serialized)
+
+
+@dataclass
+class SupabaseConfig:
+    url: Optional[str]
+    key: Optional[str]
+
+
+class SupabaseClient:
+    def __init__(
+        self,
+        url: str | None = None,
+        key: str | None = None,
+        *,
+        timeout: float = 10.0,
+    ) -> None:
+        config = SupabaseConfig(url or os.getenv("SUPABASE_URL"), key or os.getenv("SUPABASE_KEY"))
+        self._enabled = bool(config.url and config.key)
+        self._client: httpx.AsyncClient | None = None
+        if self._enabled:
+            base_url = config.url.rstrip("/") + "/rest/v1"
+            headers = {
+                "apikey": config.key,
+                "Authorization": f"Bearer {config.key}",
+                "Content-Type": "application/json",
+            }
+            self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout, headers=headers)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def aclose(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def insert_token_usage(
+        self,
+        *,
+        model: str,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+        total_tokens: int | None,
+        request_id: str | None,
+        meta: Dict[str, Any] | None = None,
+    ) -> bool:
+        if not self._client:
+            logging.debug("Supabase client disabled; skipping token usage upload")
+            return False
+
+        payload: Dict[str, Any] = {
+            "bot": "kotopogoda",
+            "model": model,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "request_id": request_id,
+            "endpoint": "responses",
+            "meta": _normalize_meta(meta),
+            "at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            response = await self._client.post(
+                "/token_usage",
+                json=payload,
+                headers={"Prefer": "return=minimal"},
+            )
+            if response.status_code not in (200, 201, 204):
+                logging.error(
+                    "Supabase token usage insert failed: %s %s",
+                    response.status_code,
+                    response.text,
+                    extra={"log_token_usage": payload},
+                )
+                return False
+            logging.info(
+                "Supabase token usage insert succeeded",
+                extra={"log_token_usage": payload},
+            )
+            return True
+        except httpx.HTTPError as exc:
+            logging.error(
+                "Supabase token usage insert error: %s",
+                exc,
+                extra={"log_token_usage": payload},
+            )
+            return False

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from supabase_client import SupabaseClient
+
+
+@pytest.mark.asyncio
+async def test_insert_token_usage_success(monkeypatch, caplog):
+    client = SupabaseClient(url="https://example.supabase.co", key="test-key")
+    response = type("Resp", (), {"status_code": 201, "text": "Created"})()
+    post_mock = AsyncMock(return_value=response)
+    monkeypatch.setattr(client._client, "post", post_mock)
+    caplog.set_level(logging.INFO)
+
+    meta = {"source": "test", "time": datetime(2024, 1, 1, tzinfo=timezone.utc)}
+    assert await client.insert_token_usage(
+        model="gpt-4o",
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        request_id="req-1",
+        meta=meta,
+    )
+    await client.aclose()
+
+    assert post_mock.await_count == 1
+    payload = post_mock.await_args.kwargs["json"]
+    assert payload["model"] == "gpt-4o"
+    assert payload["meta"]["source"] == "test"
+    assert payload["meta"]["time"].startswith("2024-01-01")
+    record = next(record for record in caplog.records if "Supabase token usage insert succeeded" in record.message)
+    assert record.log_token_usage["model"] == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_insert_token_usage_http_error(monkeypatch, caplog):
+    client = SupabaseClient(url="https://example.supabase.co", key="test-key")
+    post_mock = AsyncMock(side_effect=httpx.HTTPError("boom"))
+    monkeypatch.setattr(client._client, "post", post_mock)
+    caplog.set_level(logging.ERROR)
+
+    result = await client.insert_token_usage(
+        model="gpt-4o",
+        prompt_tokens=None,
+        completion_tokens=None,
+        total_tokens=None,
+        request_id=None,
+        meta=None,
+    )
+    await client.aclose()
+
+    assert result is False
+    record = next(record for record in caplog.records if "Supabase token usage insert error" in record.message)
+    assert record.log_token_usage["model"] == "gpt-4o"


### PR DESCRIPTION
## Summary
- add an async Supabase client that posts token-usage rows with serialized metadata and logging
- propagate OpenAI response meta and job context through the bot so Supabase receives enriched records
- document Supabase environment variables and add unit tests for the new client

## Testing
- pytest --disable-warnings -q

------
https://chatgpt.com/codex/tasks/task_e_68e2b621d66c8332ae24ffcdaa8db5c3