### PR TITLE
Document Supabase token logging details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Supabase integration that mirrors OpenAI token usage into `token_usage` via `SUPABASE_URL`/`SUPABASE_KEY`, including job metadata for downstream analytics.
+- Supabase integration that mirrors OpenAI token usage into `token_usage` via `SUPABASE_URL`/`SUPABASE_KEY`, including job metadata for downstream analytics and structured `log_token_usage` log lines mirroring the payload when inserts succeed or fail.
 - `/help` command that delivers a Markdown help guide with links to admin-interface workflows and manual button instructions.
 - Dual asset channel support with new `/set_weather_assets_channel` and `/set_recognition_channel` commands plus migration `0014_split_asset_channels.sql` that creates the recognition table and marks asset origins.
 - Regression coverage that simulates both channels to ensure weather posts ignore recognition-only assets.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 - `OPENAI_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
 - `OPENAI_DAILY_TOKEN_LIMIT`, `OPENAI_DAILY_TOKEN_LIMIT_4O`, `OPENAI_DAILY_TOKEN_LIMIT_4O_MINI` – optional per-model quotas that gate new OpenAI jobs until the next UTC reset.
 - `PORT` – HTTP port that `web.run_app` listens on (default `8080`). Ensure it matches the port exposed by your proxy or hosting platform (Fly.io, Docker, etc.) so inbound requests reach the app.
-- `SUPABASE_URL`, `SUPABASE_KEY` – optional credentials for the Supabase project that receives OpenAI token usage events. When configured the bot mirrors SQLite usage rows into the `token_usage` table for centralized analytics.
+- `SUPABASE_URL`, `SUPABASE_KEY` – optional credentials for the Supabase project that receives OpenAI token usage events. When configured the bot mirrors SQLite usage rows into the `token_usage` table for centralized analytics, storing `bot`, `model`, prompt/completion/total token counts, `request_id`, `endpoint` (`responses`), `meta` (JSON) and timestamp `at` in UTC ISO8601. Each Supabase call also emits a structured `log_token_usage` record so log shippers can archive the same payloads even if the insert fails.
 
 ### External services
 - **Nominatim** – the bot queries `https://nominatim.openstreetmap.org/reverse` and rate-limits calls to one request per second. Set `User-Agent` friendly values in the code if you fork, and consider running your own Nominatim instance for higher throughput.

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import logging
+import os
+import sys
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from supabase_client import SupabaseClient
 
 


### PR DESCRIPTION
## Summary
- document the Supabase token usage payload fields and structured log payload for downstream collectors
- update changelog to note the new log emission alongside the Supabase mirror
- fix the Supabase client test to import the module from the repository root

## Testing
- pytest tests/test_supabase_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c2f582448332818b73d42ee0fedb