### PR TITLE
Randomize asset selection and track usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -4967,6 +4967,7 @@ class Bot:
             message_id = int(result_payload.get("message_id") or 0)
         else:
             message_id = 0
+        self.data.mark_assets_used(asset.id for asset in assets)
         metadata = {
             "rubric_code": rubric.code,
             "asset_ids": [asset.id for asset in assets],
@@ -5230,6 +5231,7 @@ class Bot:
             message_id = int(result_payload.get("message_id") or 0)
         else:
             message_id = 0
+        self.data.mark_assets_used(asset.id for asset in assets)
         metadata = {
             "rubric_code": rubric.code,
             "asset_ids": [asset.id for asset in assets],


### PR DESCRIPTION
## Summary
- shuffle randomly requested assets before slicing and add a helper to stamp last_used_at
- update the flowers and guess_arch publishers to record asset usage after successful posts
- add a regression test ensuring consecutive flower runs pick different media when enough assets exist

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c42799a88332928a999cc2a774a3