### PR TITLE
Improve OpenAI key discovery and runtime refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - `SCHED_INTERVAL_SEC` – polling cadence for the scheduler loop (default `30`).
 - `PORT` – aiohttp listener used when calling `web.run_app`; defaults to `8080` and must align with the port exposed by your hosting provider.
 - `OPENAI_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
+- `OPENAI_API_KEY_FILE` – optional path to a file containing the OpenAI key. When set, the bot reads and trims the file contents and uses it if the variable `OPENAI_API_KEY` itself is not defined.
 - `OPENAI_DAILY_TOKEN_LIMIT`, `OPENAI_DAILY_TOKEN_LIMIT_4O`, `OPENAI_DAILY_TOKEN_LIMIT_4O_MINI` – optional per-model quotas that gate new OpenAI jobs until the next UTC reset.
 - `PORT` – HTTP port that `web.run_app` listens on (default `8080`). Ensure it matches the port exposed by your proxy or hosting platform (Fly.io, Docker, etc.) so inbound requests reach the app.
 - `SUPABASE_URL`, `SUPABASE_KEY` – optional credentials for the Supabase project that receives OpenAI token usage events. When configured the bot mirrors SQLite usage rows into the `token_usage` table for centralized analytics, storing `bot`, `model`, prompt/completion/total token counts, `request_id`, `endpoint` (`responses`), strictly JSON-serialized `meta` and timestamp `at` in UTC ISO8601. Each Supabase call also emits a structured `log_token_usage` record – identical for successes and failures – so log shippers can archive the same payloads even when Supabase is unreachable.

--- a/main.py
+++ b/main.py
@@ -1990,6 +1990,8 @@ class Bot:
                     local_path,
                     asset_id,
                 )
+            if self.openai and not self.openai.api_key:
+                self.openai.refresh_api_key()
             if self.dry_run or not self.openai or not self.openai.api_key:
                 if self.dry_run:
                     logging.info(


### PR DESCRIPTION
## Summary
- allow the OpenAI client to trim its configured key, reload it from the environment (or optional OPENAI_API_KEY_FILE) and expose a refresh helper
- refresh the key inside the vision job before skipping so secret updates take effect without a restart
- document the OPENAI_API_KEY_FILE option for operators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2e23382a08332bf284ff7dcad5606