### PR TITLE
Switch to 4o API key and model names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - 2024-05-17
 ### Added
-- Automatic recognition pipeline that classifies ingested assets with OpenAI `gpt-4o-mini`, stores architectural metadata and detects flowers for downstream rubrics.
+- Automatic recognition pipeline that classifies ingested assets with OpenAI `4o-mini`, stores architectural metadata and detects flowers for downstream rubrics.
 - Persistent asynchronous job queue that schedules recognition, rubric publication and manual overrides with retry/backoff semantics.
 - Daily rubrics «Цветы» and «Угадай» that assemble carousels and quizzes from recognized assets and clean up consumed media.
 - Token accounting with per-model daily quotas to prevent OpenAI overages and surface usage to administrators.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [Полную историю изменений см. в `CHANGELOG.md`](CHANGELOG.md).
 
 - **Asset ingestion**. The bot listens to the dedicated recognition channel for new submissions while weather-ready assets live in a separate storage channel. Every photo must contain GPS EXIF data so the bot can resolve the city through Nominatim; authors without coordinates receive an automatic reminder.
-- **Recognition pipeline**. After ingestion the asynchronous job queue schedules a `vision` task that classifies the photo with OpenAI `gpt-4o-mini`, storing the rubric category, architectural details and detected flowers while respecting per-model daily token quotas configured via environment variables.
+- **Recognition pipeline**. After ingestion the asynchronous job queue schedules a `vision` task that classifies the photo with OpenAI `4o-mini`, storing the rubric category, architectural details and detected flowers while respecting per-model daily token quotas configured via environment variables.
 - **Rubric automation**. Two daily rubrics are supported out of the box: `flowers` creates a carousel with greetings for cities detected in flower assets, while `guess_arch` prepares a numbered architecture quiz with optional overlays and weather context. Both rubrics consume recognized assets and clean them up after publishing, auto-initialize on first run and are fully managed through the `/rubrics` inline dashboard.
 - **Admin workflow**. Superadmins manage user access, asset channel binding and rubric schedules directly inside Telegram via commands and inline buttons. The admin interface also exposes manual approval queues and quick status messages for rubric runs.
 - **Operations guardrails**. OpenAI usage is rate-limited per model, reverse geocoding calls Nominatim with throttling, and each rubric publication is persisted with metadata for auditing through the admin tools.
@@ -60,8 +60,7 @@
 - `TZ_OFFSET` – default timezone applied to schedules until users pick their own offset.
 - `SCHED_INTERVAL_SEC` – polling cadence for the scheduler loop (default `30`).
 - `PORT` – aiohttp listener used when calling `web.run_app`; defaults to `8080` and must align with the port exposed by your hosting provider.
-- `OPENAI_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
-- `OPENAI_API_KEY_FILE` – optional path to a file containing the OpenAI key. When set, the bot reads and trims the file contents and uses it if the variable `OPENAI_API_KEY` itself is not defined.
+- `4O_API_KEY` – key used by the recognition pipeline and rubric copy generators; when missing, related jobs are skipped automatically.
 - `OPENAI_DAILY_TOKEN_LIMIT`, `OPENAI_DAILY_TOKEN_LIMIT_4O`, `OPENAI_DAILY_TOKEN_LIMIT_4O_MINI` – optional per-model quotas that gate new OpenAI jobs until the next UTC reset.
 - `PORT` – HTTP port that `web.run_app` listens on (default `8080`). Ensure it matches the port exposed by your proxy or hosting platform (Fly.io, Docker, etc.) so inbound requests reach the app.
 - `SUPABASE_URL`, `SUPABASE_KEY` – optional credentials for the Supabase project that receives OpenAI token usage events. When configured the bot mirrors SQLite usage rows into the `token_usage` table for centralized analytics, storing `bot`, `model`, prompt/completion/total token counts, `request_id`, `endpoint` (`responses`), strictly JSON-serialized `meta` and timestamp `at` in UTC ISO8601. Each Supabase call also emits a structured `log_token_usage` record – identical for successes and failures – so log shippers can archive the same payloads even when Supabase is unreachable.
@@ -96,7 +95,7 @@ The bot targets Fly.io and exposes a single aiohttp application on port `8080`. 
    python main.py
    ```
 
-Provision Fly.io secrets (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_URL`, `OPENAI_API_KEY`, token limits) before the first deployment.
+Provision Fly.io secrets (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_URL`, `4O_API_KEY`, token limits) before the first deployment.
 
 ## Legacy
 Historical documentation for the weather scheduler, including sea temperature handling and template placeholders, now lives in `docs/weather.md`. Those features remain in the codebase for backward compatibility but are no longer part of the primary rubric workflow.

--- a/architectural_overview.md
+++ b/architectural_overview.md
@@ -16,7 +16,7 @@ The aiohttp bot handles Telegram webhooks, user commands and inline callbacks. I
 Incoming photos from the assets channel trigger an ingest job. The job downloads the original media, validates EXIF GPS coordinates, stores the file locally, reverse-geocodes coordinates via Nominatim, and updates the asset record with derived metadata.
 
 ### 3.3 Recognition
-A follow-up `vision` job classifies each asset with OpenAI (`gpt-4o-mini`) to extract a primary category, architecture view, flower varieties and weather description. The job respects model quotas and logs token usage for auditing.
+A follow-up `vision` job classifies each asset with OpenAI (`4o-mini`) to extract a primary category, architecture view, flower varieties and weather description. The job respects model quotas and logs token usage for auditing.
 
 ### 3.4 Rubric engine
 Configured rubrics (`flowers`, `guess_arch`) pull classified assets, render text using OpenAI where required, overlay numbers on quiz photos, and publish carousels back to Telegram channels. Number badges respect a fixed safe zone: 24 px padding from the top-left corner on standard frames, or 12 px when the shorter photo side falls below 480 px, so designers should keep critical details outside that area. After a successful run the consumed assets and temporary overlays are removed.

--- a/main.py
+++ b/main.py
@@ -324,7 +324,7 @@ class Bot:
         self.jobs.register_handler("ingest", self._job_ingest)
         self.jobs.register_handler("vision", self._job_vision)
         self.jobs.register_handler("publish_rubric", self._job_publish_rubric)
-        self.openai = OpenAIClient(os.getenv("OPENAI_API_KEY"))
+        self.openai = OpenAIClient(os.getenv("4O_API_KEY"))
         self.supabase = SupabaseClient()
         self._model_limits = self._load_model_limits()
         asset_dir = os.getenv("ASSET_STORAGE_DIR")
@@ -472,11 +472,11 @@ class Bot:
             os.getenv("OPENAI_DAILY_TOKEN_LIMIT_4O_MINI"), "OPENAI_DAILY_TOKEN_LIMIT_4O_MINI"
         )
         if limit_4o is not None:
-            limits["gpt-4o"] = limit_4o
+            limits["4o"] = limit_4o
         if limit_4o_mini is not None:
-            limits["gpt-4o-mini"] = limit_4o_mini
+            limits["4o-mini"] = limit_4o_mini
         if not limits and default_limit is not None:
-            limits = {"gpt-4o": default_limit, "gpt-4o-mini": default_limit}
+            limits = {"4o": default_limit, "4o-mini": default_limit}
         return limits
 
     def _enforce_openai_limit(self, job: Job | None, model: str) -> None:
@@ -2073,15 +2073,15 @@ class Bot:
             user_prompt = (
                 "Определи по фото категорию, архитектурный вид, погоду и перечисли заметные цветы. Верни только JSON согласно схеме."
             )
-            self._enforce_openai_limit(job, "gpt-4o-mini")
+            self._enforce_openai_limit(job, "4o-mini")
             logging.info(
-                "Vision job %s classifying asset %s using gpt-4o-mini from %s",
+                "Vision job %s classifying asset %s using 4o-mini from %s",
                 job.id,
                 asset_id,
                 local_path,
             )
             response = await self.openai.classify_image(
-                model="gpt-4o-mini",
+                model="4o-mini",
                 system_prompt=system_prompt,
                 user_prompt=user_prompt,
                 image_bytes=image_bytes,
@@ -2146,7 +2146,7 @@ class Bot:
             caption_text = "\n".join(line for line in caption_lines if line)
             result_payload = {
                 "status": "ok",
-                "provider": "gpt-4o-mini",
+                "provider": "4o-mini",
                 "category": category,
                 "arch_view": arch_view,
                 "photo_weather": photo_weather,
@@ -2197,7 +2197,7 @@ class Bot:
                 vision_caption=caption_text,
                 local_path=local_path,
             )
-            await self._record_openai_usage("gpt-4o-mini", response, job=job)
+            await self._record_openai_usage("4o-mini", response, job=job)
             if not self.dry_run and new_mid:
                 logging.info(
                     "Vision job %s deleting original message %s for asset %s",
@@ -5144,14 +5144,14 @@ class Bot:
             try:
                 logging.info(
                     "Запрос генерации текста для цветов: модель=%s temperature=%.2f top_p=0.9 попытка %s/%s",
-                    "gpt-4o",
+                    "4o",
                     temperature,
                     attempt,
                     attempts,
                 )
-                self._enforce_openai_limit(job, "gpt-4o")
+                self._enforce_openai_limit(job, "4o")
                 response = await self.openai.generate_json(
-                    model="gpt-4o",
+                    model="4o",
                     system_prompt=(
                         "Ты редактор телеграм-канала про погоду и уют. "
                         "Создавай дружелюбные тексты."
@@ -5165,7 +5165,7 @@ class Bot:
                 logging.exception("Failed to generate flowers copy (attempt %s)", attempt)
                 response = None
             if response:
-                await self._record_openai_usage("gpt-4o", response, job=job)
+                await self._record_openai_usage("4o", response, job=job)
             if not response or not isinstance(response.content, dict):
                 continue
             greeting = str(response.content.get("greeting") or "").strip()
@@ -5411,14 +5411,14 @@ class Bot:
             try:
                 logging.info(
                     "Запрос генерации текста для guess_arch: модель=%s temperature=%.2f top_p=0.9 попытка %s/%s",
-                    "gpt-4o",
+                    "4o",
                     temperature,
                     attempt,
                     attempts,
                 )
-                self._enforce_openai_limit(job, "gpt-4o")
+                self._enforce_openai_limit(job, "4o")
                 response = await self.openai.generate_json(
-                    model="gpt-4o",
+                    model="4o",
                     system_prompt=(
                         "Ты редактор телеграм-канала о погоде и городе. "
                         "Пиши интересно, но коротко."
@@ -5432,7 +5432,7 @@ class Bot:
                 logging.exception("Failed to generate guess_arch caption (attempt %s)", attempt)
                 response = None
             if response:
-                await self._record_openai_usage("gpt-4o", response, job=job)
+                await self._record_openai_usage("4o", response, job=job)
             if not response or not isinstance(response.content, dict):
                 continue
             caption = str(response.content.get("caption") or "").strip()

--- a/openai_client.py
+++ b/openai_client.py
@@ -6,7 +6,6 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Dict
 
 import httpx
@@ -31,33 +30,21 @@ class OpenAIClient:
         if not self.api_key:
             self.api_key = self._load_api_key_from_env()
         if not self.api_key:
-            logging.warning("OpenAI API key not configured; vision tasks will be skipped")
+            logging.warning("4O API key not configured; vision tasks will be skipped")
 
     def _load_api_key_from_env(self) -> str | None:
-        env_key = os.getenv("OPENAI_API_KEY")
+        env_key = os.getenv("4O_API_KEY")
         if env_key and env_key.strip():
             return env_key.strip()
-        file_path = os.getenv("OPENAI_API_KEY_FILE")
-        if file_path:
-            try:
-                contents = Path(file_path).expanduser().read_text(encoding="utf-8").strip()
-            except FileNotFoundError:
-                logging.error("OPENAI_API_KEY_FILE %s not found", file_path)
-                return None
-            except OSError as exc:
-                logging.error("Failed reading OPENAI_API_KEY_FILE %s: %s", file_path, exc)
-                return None
-            if contents:
-                return contents
         return None
 
     def refresh_api_key(self) -> str | None:
         new_key = self._load_api_key_from_env()
         if new_key and new_key != self.api_key:
-            logging.info("OpenAI API key refreshed from environment")
+            logging.info("4O API key refreshed from environment")
         self.api_key = new_key or self.api_key
         if not self.api_key:
-            logging.warning("OpenAI API key not configured; vision tasks will be skipped")
+            logging.warning("4O API key not configured; vision tasks will be skipped")
         return self.api_key
 
     async def classify_image(

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -423,7 +423,7 @@ async def test_guess_arch_asset_selection_random(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_generate_flowers_uses_gpt4o(tmp_path):
+async def test_generate_flowers_uses_4o(tmp_path):
     bot = Bot("dummy", str(tmp_path / "db.sqlite"))
     config = {"enabled": True}
     _insert_rubric(bot, "flowers", config, rubric_id=1)
@@ -453,7 +453,7 @@ async def test_generate_flowers_uses_gpt4o(tmp_path):
     assert hashtags == ["котопогода", "цветы"]
     assert calls, "generate_json was not called"
     request = calls[0]
-    assert request["model"] == "gpt-4o"
+    assert request["model"] == "4o"
     assert 0.9 <= request["temperature"] <= 1.1
     assert request["top_p"] == 0.9
 
@@ -508,7 +508,7 @@ async def test_generate_flowers_retries_on_duplicate(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_generate_guess_arch_uses_gpt4o(tmp_path):
+async def test_generate_guess_arch_uses_4o(tmp_path):
     bot = Bot("dummy", str(tmp_path / "db.sqlite"))
     config = {"enabled": True}
     _insert_rubric(bot, "guess_arch", config, rubric_id=2)
@@ -538,7 +538,7 @@ async def test_generate_guess_arch_uses_gpt4o(tmp_path):
     assert hashtags == ["угадай", "архитектура"]
     assert calls
     request = calls[0]
-    assert request["model"] == "gpt-4o"
+    assert request["model"] == "4o"
     assert 0.9 <= request["temperature"] <= 1.1
     assert request["top_p"] == 0.9
 

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -21,7 +21,7 @@ async def test_insert_token_usage_success(monkeypatch):
 
     meta = {"source": "test", "time": datetime(2024, 1, 1, tzinfo=timezone.utc)}
     success, payload, error = await client.insert_token_usage(
-        model="gpt-4o",
+        model="4o",
         prompt_tokens=10,
         completion_tokens=5,
         total_tokens=15,
@@ -45,7 +45,7 @@ async def test_insert_token_usage_http_error(monkeypatch):
     monkeypatch.setattr(client._client, "post", post_mock)
 
     success, payload, error = await client.insert_token_usage(
-        model="gpt-4o",
+        model="4o",
         prompt_tokens=None,
         completion_tokens=None,
         total_tokens=None,
@@ -56,7 +56,7 @@ async def test_insert_token_usage_http_error(monkeypatch):
 
     assert success is False
     assert "boom" in (error or "")
-    assert payload["model"] == "gpt-4o"
+    assert payload["model"] == "4o"
 
 
 @pytest.mark.asyncio
@@ -65,7 +65,7 @@ async def test_insert_token_usage_meta_strict():
 
     with pytest.raises(TypeError):
         await client.insert_token_usage(
-            model="gpt-4o",
+            model="4o",
             prompt_tokens=1,
             completion_tokens=2,
             total_tokens=3,

--- a/tests/test_token_limits.py
+++ b/tests/test_token_limits.py
@@ -36,17 +36,17 @@ async def test_token_usage_total_respects_timezone(tmp_path):
     ]
     for ts, total in entries:
         bot.data.log_token_usage(
-            "gpt-4o",
+            "4o",
             total,
             None,
             total,
             timestamp=ts,
         )
     total = bot.data.get_daily_token_usage_total(
-        day=date(2024, 6, 2), models={"gpt-4o"}, tz_offset="+03:00"
+        day=date(2024, 6, 2), models={"4o"}, tz_offset="+03:00"
     )
     assert total == 18
     # Default timezone fallback should use global TZ_OFFSET when tz is None
-    default_total = bot.data.get_daily_token_usage_total(models={"gpt-4o"})
+    default_total = bot.data.get_daily_token_usage_total(models={"4o"})
     assert isinstance(default_total, int)
     await bot.close()

--- a/tests/test_token_usage_logging.py
+++ b/tests/test_token_usage_logging.py
@@ -18,7 +18,7 @@ async def test_record_openai_usage_logs_success(tmp_path, caplog, monkeypatch):
     bot = Bot("dummy", str(tmp_path / "db.sqlite"))
     payload = {
         "bot": "kotopogoda",
-        "model": "gpt-4o",
+        "model": "4o",
         "prompt_tokens": 10,
         "completion_tokens": 5,
         "total_tokens": 15,
@@ -33,7 +33,7 @@ async def test_record_openai_usage_logs_success(tmp_path, caplog, monkeypatch):
 
     job = SimpleNamespace(id=123, name="vision", payload={"foo": "bar"})
     response = OpenAIResponse({}, 10, 5, 15, request_id="req-1", meta={})
-    await bot._record_openai_usage("gpt-4o", response, job=job)
+    await bot._record_openai_usage("4o", response, job=job)
 
     assert mock_insert.await_count == 1
     insert_kwargs = mock_insert.await_args.kwargs
@@ -47,13 +47,13 @@ async def test_record_openai_usage_logs_success(tmp_path, caplog, monkeypatch):
 @pytest.mark.asyncio
 async def test_record_openai_usage_logs_failure(tmp_path, caplog, monkeypatch):
     bot = Bot("dummy", str(tmp_path / "db.sqlite"))
-    payload = {"bot": "kotopogoda", "model": "gpt-4o"}
+    payload = {"bot": "kotopogoda", "model": "4o"}
     mock_insert = AsyncMock(return_value=(False, payload, "HTTP 500: error"))
     monkeypatch.setattr(bot.supabase, "insert_token_usage", mock_insert)
     caplog.set_level(logging.ERROR)
 
     response = OpenAIResponse({}, 1, 2, 3, request_id="req-2", meta=None)
-    await bot._record_openai_usage("gpt-4o", response)
+    await bot._record_openai_usage("4o", response)
 
     record = next(rec for rec in caplog.records if "Supabase token usage insert failed" in rec.message)
     assert record.log_token_usage == payload


### PR DESCRIPTION
## Summary
- switch the OpenAI client to load the 4O_API_KEY secret and drop the unused file-based fallback
- align the bot’s OpenAI usage with the 4o/4o-mini model identifiers, including quota accounting and logging
- refresh documentation and tests to reflect the renamed key and model selections

## Testing
- pytest tests/test_rubrics.py::test_generate_flowers_uses_4o tests/test_rubrics.py::test_generate_guess_arch_uses_4o tests/test_supabase_client.py tests/test_token_limits.py tests/test_token_usage_logging.py


------
https://chatgpt.com/codex/tasks/task_e_68e2e996c24c8332acdd4db917f007f6