### PR TITLE
Fix OpenAI Responses payload schema and token accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression coverage that simulates both channels to ensure weather posts ignore recognition-only assets.
 
 ### Changed
+- Updated the OpenAI Responses payload to use the latest `response_format` schema and
+  ensured token usage metrics persist to Supabase with non-null totals.
 - `/set_assets_channel` now updates both channel roles for backward compatibility, while `publish_weather` only copies from the weather storage channel and leaves source messages untouched.
 - `guess_arch` overlays now scale to 10–16% of the shortest image side so custom PNG badges stay proportional across photo sizes.
 

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -97,8 +97,17 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert captured["url"].endswith("/responses")
     payload = captured["payload"]
     assert payload["model"] == "gpt-vision"
-    assert payload["response"]["modalities"] == ["text"]
-    assert payload["response"]["text"]["format"]["json_schema"] is schema
+    assert payload["modalities"] == ["text"]
+    assert payload["response_format"]["type"] == "json_schema"
+    assert payload["response_format"]["json_schema"] is schema
+    assert payload["response_format"]["strict"] is True
+    system_content = payload["input"][0]["content"][0]
+    assert system_content == {
+        "type": "input_text",
+        "text": "classify image",
+    }
+    user_text = payload["input"][1]["content"][0]
+    assert user_text == {"type": "input_text", "text": "What do you see?"}
     image_part = payload["input"][1]["content"][1]
     assert image_part["type"] == "input_image"
     assert base64.b64decode(image_part["image_base64"]) == b"fake-bytes"
@@ -157,8 +166,17 @@ async def test_generate_json_uses_text_response_payload(monkeypatch):
 
     payload = captured["payload"]
     assert payload["model"] == "gpt-json"
-    assert payload["response"]["modalities"] == ["text"]
-    assert payload["response"]["text"]["format"]["json_schema"] is schema
+    assert payload["modalities"] == ["text"]
+    assert payload["response_format"]["type"] == "json_schema"
+    assert payload["response_format"]["json_schema"] is schema
+    assert payload["response_format"]["strict"] is True
+    system_content = payload["input"][0]["content"][0]
+    assert system_content == {
+        "type": "input_text",
+        "text": "You are a helpful assistant",
+    }
+    user_content = payload["input"][1]["content"][0]
+    assert user_content == {"type": "input_text", "text": "Say hello"}
     assert payload["temperature"] == 0.1
     assert payload["top_p"] == 0.9
 


### PR DESCRIPTION
## Summary
- update the OpenAI client payload to use response_format, move modalities to the request root, and normalize input_text segments for system and user prompts
- parse new usage.input_tokens/output_tokens fields with graceful fallbacks and compute total token counts for Supabase logging
- refresh the changelog and adjust unit tests to match the new payload shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2f4c756388332b1e3ddb975f102a2