### PR TITLE
Reduce persistent asset storage usage

### DIFF
--- a/data_access.py
+++ b/data_access.py
@@ -301,7 +301,7 @@ class DataAccess:
         vision_flower_varieties: list[str] | None = None,
         vision_confidence: float | None = None,
         exif_present: bool | None = None,
-        local_path: str | None = None,
+        local_path: str | None | object = _UNSET,
         vision_caption: str | None = None,
         origin: str | None = None,
     ) -> None:
@@ -365,7 +365,7 @@ class DataAccess:
             values["country"] = country
         if exif_present is not None:
             values["exif_present"] = int(bool(exif_present))
-        if local_path is not None:
+        if local_path is not _UNSET:
             values["local_path"] = local_path
         if vision_category is not None:
             values["vision_category"] = vision_category


### PR DESCRIPTION
## Summary
- allow clearing stored asset file paths in the data layer
- download asset files only temporarily during ingest, vision, and overlay preparation and delete them afterward
- fetch source images on demand for guess_arch overlays while updating asset records to drop local paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2da87bf3c8332a57543d645ff637f