### PR TITLE
Fix OpenAI Responses payloads

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -60,15 +60,13 @@ class OpenAIClient:
             return None
         payload = {
             "model": model,
-            "response": {
-                "modalities": ["text"],
-                "text": {
-                    "format": {
-                        "type": "json_schema",
-                        "json_schema": schema,
-                        "strict": True,
-                    }
-                },
+            "modalities": ["text"],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "json_schema": schema,
+                    "strict": True,
+                }
             },
             "input": [
                 {
@@ -86,7 +84,7 @@ class OpenAIClient:
                         {"type": "input_text", "text": user_prompt},
                         {
                             "type": "input_image",
-                            "image_base64": base64.b64encode(image_bytes).decode("ascii"),
+                            "image_url": self._encode_image_as_data_uri(image_bytes),
                         },
                     ],
                 },
@@ -108,15 +106,13 @@ class OpenAIClient:
             return None
         payload = {
             "model": model,
-            "response": {
-                "modalities": ["text"],
-                "text": {
-                    "format": {
-                        "type": "json_schema",
-                        "json_schema": schema,
-                        "strict": True,
-                    }
-                },
+            "modalities": ["text"],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "json_schema": schema,
+                    "strict": True,
+                }
             },
             "input": [
                 {
@@ -134,6 +130,33 @@ class OpenAIClient:
         if top_p is not None:
             payload["top_p"] = top_p
         return await self._submit_request(payload)
+
+    def _encode_image_as_data_uri(self, image_bytes: bytes) -> str:
+        mime_type = self._detect_mime_type(image_bytes)
+        base64_data = base64.b64encode(image_bytes).decode("ascii")
+        return f"data:{mime_type};base64,{base64_data}"
+
+    def _detect_mime_type(self, image_bytes: bytes) -> str:
+        header = image_bytes[:12]
+        if header.startswith(b"\xff\xd8\xff"):
+            return "image/jpeg"
+        if header.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png"
+        if header[:6] in (b"GIF87a", b"GIF89a"):
+            return "image/gif"
+        if header.startswith(b"BM"):
+            return "image/bmp"
+        if len(image_bytes) >= 12 and header[0:4] == b"RIFF" and image_bytes[8:12] == b"WEBP":
+            return "image/webp"
+        if header.startswith(b"II*\x00") or header.startswith(b"MM\x00*"):
+            return "image/tiff"
+        if len(image_bytes) >= 12 and header[4:8] == b"ftyp":
+            brand = image_bytes[8:12]
+            if brand in {b"heic", b"heix", b"hevc", b"hevx"}:
+                return "image/heic"
+            if brand in {b"mif1", b"msf1"}:
+                return "image/heif"
+        return "image/jpeg"
 
     async def _submit_request(self, payload: Dict[str, Any]) -> OpenAIResponse:
         url = f"{self.base_url}/responses"

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -97,9 +97,8 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert captured["url"].endswith("/responses")
     payload = captured["payload"]
     assert payload["model"] == "gpt-vision"
-    response_section = payload["response"]
-    assert response_section["modalities"] == ["text"]
-    text_config = response_section["text"]["format"]
+    assert payload["modalities"] == ["text"]
+    text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
     assert text_config["json_schema"] is schema
     assert text_config["strict"] is True
@@ -112,7 +111,9 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert user_text == {"type": "input_text", "text": "What do you see?"}
     image_part = payload["input"][1]["content"][1]
     assert image_part["type"] == "input_image"
-    assert base64.b64decode(image_part["image_base64"]) == b"fake-bytes"
+    assert image_part["image_url"].startswith("data:image/jpeg;base64,")
+    encoded = image_part["image_url"].split(",", 1)[1]
+    assert base64.b64decode(encoded) == b"fake-bytes"
 
     assert result is not None
     assert result.content == expected_result
@@ -168,9 +169,8 @@ async def test_generate_json_uses_text_response_payload(monkeypatch):
 
     payload = captured["payload"]
     assert payload["model"] == "gpt-json"
-    response_section = payload["response"]
-    assert response_section["modalities"] == ["text"]
-    text_config = response_section["text"]["format"]
+    assert payload["modalities"] == ["text"]
+    text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
     assert text_config["json_schema"] is schema
     assert text_config["strict"] is True


### PR DESCRIPTION
## Summary
- update classify_image payload for the Responses API to use top-level modalities/text settings and data URI images
- update generate_json payload to match the latest structured output contract and add MIME detection helper
- adjust client tests to assert the new payload shape and data URI encoding

## Testing
- pytest tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e2fd1c1d84833296dd76d59c22abcd