### PR TITLE
Update Responses API payloads

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -97,10 +97,10 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert captured["url"].endswith("/responses")
     payload = captured["payload"]
     assert payload["model"] == "gpt-vision"
-    assert payload["modalities"] == ["text"]
     text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
-    assert text_config["json_schema"] is schema
+    assert text_config["json_schema"]["name"] == "vision"
+    assert text_config["json_schema"]["schema"] is schema["schema"]
     assert text_config["strict"] is True
     system_content = payload["input"][0]["content"][0]
     assert system_content == {
@@ -169,10 +169,10 @@ async def test_generate_json_uses_text_response_payload(monkeypatch):
 
     payload = captured["payload"]
     assert payload["model"] == "gpt-json"
-    assert payload["modalities"] == ["text"]
     text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
-    assert text_config["json_schema"] is schema
+    assert text_config["json_schema"]["name"] == "json"
+    assert text_config["json_schema"]["schema"] is schema["schema"]
     assert text_config["strict"] is True
     system_content = payload["input"][0]["content"][0]
     assert system_content == {


### PR DESCRIPTION
## Summary
- remove deprecated modalities field from JSON payloads
- wrap json schema requests in the new Responses API text.format structure
- ensure image inputs use data URI with detected MIME type and more resilient usage parsing

## Testing
- pytest tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e3805c5ad88332b5e538834f49eec3