### PR TITLE
Add schema names to OpenAI Responses payloads

### DIFF
--- a/main.py
+++ b/main.py
@@ -485,15 +485,12 @@ class Bot:
             return
 
         schema = {
-            "name": "openai_health_check",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "ok": {"type": "boolean"},
-                },
-                "required": ["ok"],
-                "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "ok": {"type": "boolean"},
             },
+            "required": ["ok"],
+            "additionalProperties": False,
         }
 
         try:
@@ -502,6 +499,7 @@ class Bot:
                 system_prompt="You are a readiness probe.",
                 user_prompt="Return a JSON object with ok=true.",
                 schema=schema,
+                schema_name="health_check_v1",
                 temperature=0.0,
             )
         except Exception:
@@ -2067,50 +2065,47 @@ class Bot:
                 image_bytes = fh.read()
 
             schema = {
-                "name": "vision_classification",
-                "schema": {
-                    "type": "object",
-                    "title": "Vision classification payload",
-                    "description": (
-                        "Заполни сведения о категории сюжета, архитектурном виде, погоде на фото и "
-                        "цветах согласно §3.1."
-                    ),
-                    "properties": {
-                        "category": {
-                            "type": "string",
-                            "description": "Основная классификация сюжета фотографии",
-                            "minLength": 1,
-                        },
-                        "arch_view": {
-                            "type": "string",
-                            "description": "Описание архитектурных элементов или вида (если их нет — пустая строка)",
-                            "default": "",
-                        },
-                        "photo_weather": {
-                            "type": "string",
-                            "description": "Краткое описание погодных условий, видимых на изображении",
-                            "minLength": 1,
-                        },
-                        "flower_varieties": {
-                            "type": "array",
-                            "description": "Перечень цветов, различимых на фото",
-                            "items": {
-                                "type": "string",
-                                "minLength": 1,
-                            },
-                            "minItems": 0,
-                            "default": [],
-                        },
-                        "confidence": {
-                            "type": "number",
-                            "description": "Уверенность модели (0.0–1.0)",
-                            "minimum": 0,
-                            "maximum": 1,
-                        },
+                "type": "object",
+                "title": "Vision classification payload",
+                "description": (
+                    "Заполни сведения о категории сюжета, архитектурном виде, погоде на фото и "
+                    "цветах согласно §3.1."
+                ),
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "description": "Основная классификация сюжета фотографии",
+                        "minLength": 1,
                     },
-                    "required": ["category", "photo_weather"],
-                    "additionalProperties": False,
+                    "arch_view": {
+                        "type": "string",
+                        "description": "Описание архитектурных элементов или вида (если их нет — пустая строка)",
+                        "default": "",
+                    },
+                    "photo_weather": {
+                        "type": "string",
+                        "description": "Краткое описание погодных условий, видимых на изображении",
+                        "minLength": 1,
+                    },
+                    "flower_varieties": {
+                        "type": "array",
+                        "description": "Перечень цветов, различимых на фото",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1,
+                        },
+                        "minItems": 0,
+                        "default": [],
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "description": "Уверенность модели (0.0–1.0)",
+                        "minimum": 0,
+                        "maximum": 1,
+                    },
                 },
+                "required": ["category", "photo_weather"],
+                "additionalProperties": False,
             }
             system_prompt = (
                 "Ты ассистент проекта Котопогода. Проанализируй изображение и верни JSON, строго соответствующий схеме, "
@@ -5199,19 +5194,16 @@ class Bot:
             )
         prompt = " ".join(prompt_parts)
         schema = {
-            "name": "flowers_post",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "greeting": {"type": "string"},
-                    "hashtags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "minItems": 1,
-                    },
+            "type": "object",
+            "properties": {
+                "greeting": {"type": "string"},
+                "hashtags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
                 },
-                "required": ["greeting", "hashtags"],
             },
+            "required": ["greeting", "hashtags"],
         }
         attempts = 3
         for attempt in range(1, attempts + 1):
@@ -5488,19 +5480,16 @@ class Bot:
         if weather_text:
             prompt += f" Добавь аккуратную фразу с погодой: {weather_text}."
         schema = {
-            "name": "guess_arch_post",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "caption": {"type": "string"},
-                    "hashtags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "minItems": 1,
-                    },
+            "type": "object",
+            "properties": {
+                "caption": {"type": "string"},
+                "hashtags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
                 },
-                "required": ["caption", "hashtags"],
             },
+            "required": ["caption", "hashtags"],
         }
         attempts = 3
         for attempt in range(1, attempts + 1):

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -54,7 +54,7 @@ class DummyAsyncClient:
 @pytest.mark.asyncio
 async def test_classify_image_uses_text_response_payload(monkeypatch):
     captured: dict[str, Any] = {}
-    schema = {"name": "vision", "schema": {"type": "object"}}
+    schema = {"type": "object"}
     expected_result = {"label": "cat", "confidence": 0.9}
     response_payload = {
         "output": [
@@ -99,8 +99,8 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert payload["model"] == "gpt-vision"
     text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
-    assert text_config["json_schema"]["name"] == "vision"
-    assert text_config["json_schema"]["schema"] is schema["schema"]
+    assert text_config["json_schema"]["name"] == "asset_vision_v1"
+    assert text_config["json_schema"]["schema"] is schema
     assert text_config["strict"] is True
     system_content = payload["input"][0]["content"][0]
     assert system_content == {
@@ -126,7 +126,7 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
 @pytest.mark.asyncio
 async def test_generate_json_uses_text_response_payload(monkeypatch):
     captured: dict[str, Any] = {}
-    schema = {"name": "json", "schema": {"type": "object"}}
+    schema = {"type": "object"}
     expected_result = {"message": "hello"}
     response_payload = {
         "output": [
@@ -171,8 +171,8 @@ async def test_generate_json_uses_text_response_payload(monkeypatch):
     assert payload["model"] == "gpt-json"
     text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
-    assert text_config["json_schema"]["name"] == "json"
-    assert text_config["json_schema"]["schema"] is schema["schema"]
+    assert text_config["json_schema"]["name"] == "post_text_v1"
+    assert text_config["json_schema"]["schema"] is schema
     assert text_config["strict"] is True
     system_content = payload["input"][0]["content"][0]
     assert system_content == {


### PR DESCRIPTION
## Summary
- add a helper to build structured output payloads with explicit schema names for vision, text, and health check requests
- update OpenAI retry handling to skip invalid_request_error 4xx responses while retaining retries for transient errors
- simplify local schema definitions to pass raw JSON Schema objects through the client

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e38b0ecc2c8332b831508cc5ca9abb