### PR TITLE
Update OpenAI schema format handling

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -99,8 +99,8 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert payload["model"] == "gpt-vision"
     text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
-    assert text_config["json_schema"]["name"] == "asset_vision_v1"
-    assert text_config["json_schema"]["schema"] is schema
+    assert text_config["name"] == "asset_vision_v1"
+    assert text_config["schema"] is schema
     assert text_config["strict"] is True
     system_content = payload["input"][0]["content"][0]
     assert system_content == {
@@ -171,8 +171,8 @@ async def test_generate_json_uses_text_response_payload(monkeypatch):
     assert payload["model"] == "gpt-json"
     text_config = payload["text"]["format"]
     assert text_config["type"] == "json_schema"
-    assert text_config["json_schema"]["name"] == "post_text_v1"
-    assert text_config["json_schema"]["schema"] is schema
+    assert text_config["name"] == "post_text_v1"
+    assert text_config["schema"] is schema
     assert text_config["strict"] is True
     system_content = payload["input"][0]["content"][0]
     assert system_content == {


### PR DESCRIPTION
## Summary
- flatten the OpenAI text format payload to surface schema name and body at the top level
- allow callers to override the schema name when classifying images and validate payloads against the new structure
- refresh OpenAI client tests to assert the updated response format expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3962aba0883329e94cf5b02c802da