### PR TITLE
Update vision schema handling for new fields

### DIFF
--- a/data_access.py
+++ b/data_access.py
@@ -692,7 +692,11 @@ class DataAccess:
                         continue
                     seen.add(text)
                     normalized_tags.append(text)
-            category = result.get("category") or result.get("primary_scene")
+            category = (
+                result.get("category")
+                or result.get("caption")
+                or result.get("primary_scene")
+            )
             if not category and normalized_tags:
                 category = normalized_tags[0]
             arch_view_value = result.get("arch_view")

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -241,20 +241,17 @@ async def test_recognized_message_skips_reingest(tmp_path):
         async def classify_image(self, **kwargs):
             return OpenAIResponse(
                 {
-                    'primary_scene': 'кот',
+                    'arch_view': False,
+                    'caption': 'кот',
+                    'objects': ['кот'],
+                    'is_outdoor': False,
                     'guess_country': None,
                     'guess_city': None,
-                    'arch_view': False,
-                    'weather': {'label': 'indoor', 'description': 'в помещении'},
-                    'objects': ['кот'],
+                    'location_confidence': None,
+                    'landmarks': [],
                     'tags': ['animals'],
-                    'safety': {
-                        'nsfw': False,
-                        'violence': False,
-                        'self_harm': False,
-                        'hate': False,
-                    },
-                    'notes': '',
+                    'weather': {'label': 'indoor', 'description': 'в помещении'},
+                    'safety': {'nsfw': False, 'reason': 'безопасно'},
                 },
                 prompt_tokens=10,
                 completion_tokens=5,
@@ -347,7 +344,7 @@ async def test_recognized_message_skips_reingest(tmp_path):
         'message_id': recognized_mid,
         'date': int(datetime.utcnow().timestamp()),
         'chat': {'id': -100123},
-        'caption': 'Распознано: кот',
+        'caption': 'Распознано: кот\nПогода: в помещении\nНа улице: нет\nАрхитектура: нет\nОбъекты: кот\nТеги: animals\nБезопасность: безопасно',
         'photo': [
             {
                 'file_id': 'vision_small',
@@ -407,25 +404,22 @@ async def test_recognized_edit_skips_reingest(tmp_path):
         async def classify_image(self, **kwargs):
             return OpenAIResponse(
                 {
-                    'primary_scene': 'кот',
+                    'arch_view': False,
+                    'caption': 'кот',
+                    'objects': ['кот'],
+                    'is_outdoor': False,
                     'guess_country': None,
                     'guess_city': None,
-                    'arch_view': False,
-                    'weather': {'label': 'indoor', 'description': 'в помещении'},
-                    'objects': ['кот'],
+                    'location_confidence': None,
+                    'landmarks': [],
                     'tags': ['animals'],
-                    'safety': {
-                        'nsfw': False,
-                        'violence': False,
-                        'self_harm': False,
-                        'hate': False,
-                    },
-                    'notes': '',
+                    'weather': {'label': 'indoor', 'description': 'в помещении'},
+                    'safety': {'nsfw': False, 'reason': 'безопасно'},
                 },
                 prompt_tokens=10,
                 completion_tokens=5,
                 total_tokens=15,
-                request_id='req-1',
+                request_id='req-2',
             )
 
     bot._download_file = fake_download  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- replace the asset vision schema with the new caption/is_outdoor/location fields and refresh the prompts
- adjust the vision post-processing pipeline to consume the updated response shape and build the new caption payload
- update persistence helpers and tests to assert against the revised schema and recognition captions

## Testing
- pytest tests/test_vision_results.py tests/test_weather_new.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a23fdb548332bb052b6c704b7b92