### PR TITLE
Refine response_format schema handling in OpenAI client

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -160,38 +160,28 @@ class OpenAIClient:
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-        response_format = (
+        response_format_raw = (
             payload.get("response_format") if isinstance(payload, dict) else None
         )
+        response_format = (
+            response_format_raw if isinstance(response_format_raw, dict) else {}
+        )
+        json_schema_raw = response_format.get("json_schema")
         json_schema_section = (
-            response_format.get("json_schema")
-            if isinstance(response_format, dict)
-            else None
+            json_schema_raw if isinstance(json_schema_raw, dict) else {}
         )
-        schema_name = (
-            json_schema_section.get("name")
-            if isinstance(json_schema_section, dict)
-            else None
-        )
+        schema_name = json_schema_section.get("name")
         if not schema_name or not str(schema_name).strip():
             raise ValueError(
                 "OpenAI payload must include response_format.json_schema.name"
             )
-        schema_body = (
-            json_schema_section.get("schema")
-            if isinstance(json_schema_section, dict)
-            else None
-        )
+        schema_body = json_schema_section.get("schema")
         schema_keys: list[str] | None = None
         schema_key_count: int | None = None
         if isinstance(schema_body, dict):
             schema_key_count = len(schema_body)
             schema_keys = sorted(schema_body.keys())[:5]
-        strict_flag = (
-            json_schema_section.get("strict")
-            if isinstance(json_schema_section, dict)
-            else None
-        )
+        strict_flag = json_schema_section.get("strict")
         logging.debug(
             "OpenAI payload schema summary: name=%s strict=%s key_count=%s sample_keys=%s",
             schema_name,

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -298,3 +298,20 @@ async def test_logs_invalid_json_schema_details(monkeypatch, caplog):
     log_message = relevant[0]
     assert "post_text_v1" in log_message
     assert "truncated=True" in log_message
+
+
+@pytest.mark.asyncio
+async def test_submit_request_requires_json_schema_name():
+    client = OpenAIClient("test-key")
+    payload = {
+        "model": "gpt-json",
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"schema": {"type": "object"}},
+        },
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        await client._submit_request(payload)
+
+    assert "response_format.json_schema.name" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- normalize schema metadata extraction in `_submit_request` to rely on `response_format.json_schema`
- keep structured logging while validating the presence of a schema name and recording schema metadata
- add a regression test covering the missing-schema-name error path

## Testing
- pytest tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e3bcf84d3c83329f8ed25ef9cd697f