### PR TITLE
Ensure image part precedes text in image classification payload

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -85,8 +85,8 @@ class OpenAIClient:
                 {
                     "role": "user",
                     "content": [
-                        {"type": "input_text", "text": user_prompt},
                         self._build_image_part(image_bytes),
+                        {"type": "input_text", "text": user_prompt},
                     ],
                 },
             ],

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -155,14 +155,14 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
         "type": "input_text",
         "text": "classify image",
     }
-    user_text = payload["input"][1]["content"][0]
-    assert user_text == {"type": "input_text", "text": "What do you see?"}
-    image_part = payload["input"][1]["content"][1]
+    image_part = payload["input"][1]["content"][0]
     assert image_part["type"] == "input_image"
     image_url = image_part["image_url"]
     assert image_url.startswith("data:image/png;base64,")
     encoded = image_url.split(",", 1)[1]
     assert base64.b64decode(encoded) == PNG_BYTES
+    user_text = payload["input"][1]["content"][1]
+    assert user_text == {"type": "input_text", "text": "What do you see?"}
 
     assert result is not None
     assert result.content == expected_result


### PR DESCRIPTION
## Summary
- reorder the classify_image payload so the image content precedes the text prompt
- update the classify_image test to assert the new ordering

## Testing
- pytest tests/test_openai_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cad230dc83329bb93c44b51fb28c