### PR TITLE
Handle unknown image MIME types in OpenAI client

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -149,9 +149,10 @@ class OpenAIClient:
 
     def _build_image_part(self, image_bytes: bytes) -> dict[str, Any]:
         image_kind = imghdr.what(None, image_bytes)
-        if not image_kind:
-            raise ValueError("Unable to determine image MIME type")
-        mime_type = f"image/{image_kind}"
+        if image_kind:
+            mime_type = f"image/{image_kind}"
+        else:
+            mime_type = "image/jpeg"
         base64_data = base64.b64encode(image_bytes).decode("ascii")
         return {
             "type": "input_image",

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -190,6 +190,16 @@ def test_build_image_part_jpeg_data_uri():
     assert base64.b64decode(encoded) == JPEG_BYTES
 
 
+def test_build_image_part_falls_back_to_jpeg(monkeypatch):
+    client = OpenAIClient("test-key")
+    monkeypatch.setattr("openai_client.imghdr.what", lambda *args, **kwargs: None)
+    part = client._build_image_part(PNG_BYTES)
+    assert part["type"] == "input_image"
+    assert part["image_url"].startswith("data:image/jpeg;base64,")
+    encoded = part["image_url"].split(",", 1)[1]
+    assert base64.b64decode(encoded) == PNG_BYTES
+
+
 @pytest.mark.asyncio
 async def test_generate_json_uses_text_response_payload(monkeypatch):
     captured: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- fall back to image/jpeg when image MIME detection fails while building data URLs
- extend OpenAI client tests to cover the fallback behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3cc89b1848332a801a7c5f7c89fb5