### PR TITLE
Use copyMessage for vision publication

### DIFF
--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -230,6 +230,8 @@ async def test_recognized_message_skips_reingest(tmp_path):
         return Path(dest_path)
 
     async def fake_api_request(method, data=None, *, files=None):  # type: ignore[override]
+        if method == 'copyMessage':
+            return {'ok': True, 'result': {'message_id': recognized_mid}}
         if method == 'sendPhoto':
             return {'ok': True, 'result': {'message_id': recognized_mid}}
         return {'ok': True, 'result': {}}
@@ -392,6 +394,8 @@ async def test_recognized_edit_skips_reingest(tmp_path):
         return Path(dest_path)
 
     async def fake_api_request(method, data=None, *, files=None):  # type: ignore[override]
+        if method == 'copyMessage':
+            return {'ok': True, 'result': {'message_id': recognized_mid}}
         if method == 'sendPhoto':
             return {'ok': True, 'result': {'message_id': recognized_mid}}
         return {'ok': True, 'result': {}}


### PR DESCRIPTION
## Summary
- publish vision job results with copyMessage and fall back to media-specific send methods when copying fails
- persist recognized message metadata after successful copy
- adjust recognition flow tests to expect copyMessage usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3ecdde1748332bef79544672687b2