### PR TITLE
Add structured usage payload to OpenAI responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -725,6 +725,7 @@ class Bot:
             meta.update(supabase_meta)
         if not record_supabase:
             return
+        usage = response.usage if isinstance(response.usage, dict) else {}
         success, payload, error = await self.supabase.insert_token_usage(
             bot=supabase_bot or "kotopogoda",
             model=model,
@@ -732,7 +733,7 @@ class Bot:
             completion_tokens=response.completion_tokens,
             total_tokens=response.total_tokens,
             request_id=response.request_id,
-            endpoint=supabase_endpoint or "/v1/responses",
+            endpoint=supabase_endpoint or usage.get("endpoint") or "/v1/responses",
             meta=meta or None,
         )
         log_context = {"log_token_usage": payload}
@@ -2239,6 +2240,7 @@ class Bot:
             if not isinstance(result, dict):
                 raise RuntimeError("Invalid response from vision model")
             supabase_meta = {"asset_id": asset_id, "channel_id": asset.channel_id}
+            usage = response.usage if isinstance(response.usage, dict) else {}
             success, payload, error = await self.supabase.insert_token_usage(
                 bot="kotopogoda",
                 model="gpt-4o-mini",
@@ -2246,7 +2248,7 @@ class Bot:
                 completion_tokens=response.completion_tokens,
                 total_tokens=response.total_tokens,
                 request_id=response.request_id,
-                endpoint="/v1/responses",
+                endpoint=usage.get("endpoint") or "/v1/responses",
                 meta=supabase_meta,
             )
             log_context = {"log_token_usage": payload}

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -185,7 +185,10 @@ async def test_classify_image_uses_text_response_payload(monkeypatch):
     assert result.prompt_tokens == 10
     assert result.completion_tokens == 5
     assert result.total_tokens == 15
-    assert result.request_id == "resp_vision"
+    assert result.request_id == "req_123"
+    assert result.endpoint == "/v1/responses"
+    assert result.usage["response_id"] == "resp_vision"
+    assert result.usage["request_id"] == "req_123"
 
 
 def test_build_image_part_png_data_uri():
@@ -281,7 +284,10 @@ async def test_generate_json_uses_text_response_payload(monkeypatch):
     assert result is not None
     assert result.content == expected_result
     assert result.total_tokens == 10
-    assert result.request_id == "resp_json"
+    assert result.request_id == "req_123"
+    assert result.endpoint == "/v1/responses"
+    assert result.usage["response_id"] == "resp_json"
+    assert result.usage["request_id"] == "req_123"
 
 
 @pytest.mark.asyncio

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -439,10 +439,13 @@ async def test_generate_flowers_uses_gpt_4o(tmp_path):
             calls.append(kwargs)
             return OpenAIResponse(
                 {"greeting": "Доброе утро", "hashtags": ["котопогода", "цветы"]},
-                10,
-                15,
-                25,
-                "req-1",
+                {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 15,
+                    "total_tokens": 25,
+                    "request_id": "req-1",
+                    "endpoint": "/v1/responses",
+                },
             )
 
     bot.openai = DummyOpenAI()
@@ -483,17 +486,23 @@ async def test_generate_flowers_retries_on_duplicate(tmp_path):
             if len(calls) == 1:
                 return OpenAIResponse(
                     {"greeting": "Доброе утро", "hashtags": ["#котопогода"]},
-                    5,
-                    5,
-                    10,
-                    "req-first",
+                    {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 5,
+                        "total_tokens": 10,
+                        "request_id": "req-first",
+                        "endpoint": "/v1/responses",
+                    },
                 )
             return OpenAIResponse(
                 {"greeting": "Привет, друзья", "hashtags": ["#котопогода", "#цветы"]},
-                6,
-                7,
-                13,
-                "req-second",
+                {
+                    "prompt_tokens": 6,
+                    "completion_tokens": 7,
+                    "total_tokens": 13,
+                    "request_id": "req-second",
+                    "endpoint": "/v1/responses",
+                },
             )
 
     bot.openai = DummyOpenAI()
@@ -524,10 +533,13 @@ async def test_generate_guess_arch_uses_gpt_4o(tmp_path):
             calls.append(kwargs)
             return OpenAIResponse(
                 {"caption": "Тест", "hashtags": ["угадай", "архитектура"]},
-                8,
-                9,
-                17,
-                "req-3",
+                {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 9,
+                    "total_tokens": 17,
+                    "request_id": "req-3",
+                    "endpoint": "/v1/responses",
+                },
             )
 
     bot.openai = DummyOpenAI()

--- a/tests/test_token_usage_logging.py
+++ b/tests/test_token_usage_logging.py
@@ -32,7 +32,17 @@ async def test_record_openai_usage_logs_success(tmp_path, caplog, monkeypatch):
     caplog.set_level(logging.INFO)
 
     job = SimpleNamespace(id=123, name="vision", payload={"foo": "bar"})
-    response = OpenAIResponse({}, 10, 5, 15, request_id="req-1", meta={})
+    response = OpenAIResponse(
+        {},
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "request_id": "req-1",
+            "endpoint": "/v1/responses",
+        },
+        meta={},
+    )
     await bot._record_openai_usage("gpt-4o", response, job=job)
 
     assert mock_insert.await_count == 1
@@ -52,7 +62,17 @@ async def test_record_openai_usage_logs_failure(tmp_path, caplog, monkeypatch):
     monkeypatch.setattr(bot.supabase, "insert_token_usage", mock_insert)
     caplog.set_level(logging.ERROR)
 
-    response = OpenAIResponse({}, 1, 2, 3, request_id="req-2", meta=None)
+    response = OpenAIResponse(
+        {},
+        {
+            "prompt_tokens": 1,
+            "completion_tokens": 2,
+            "total_tokens": 3,
+            "request_id": "req-2",
+            "endpoint": "/v1/responses",
+        },
+        meta=None,
+    )
     await bot._record_openai_usage("gpt-4o", response)
 
     record = next(rec for rec in caplog.records if "Supabase token usage insert failed" in rec.message)

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -254,10 +254,13 @@ async def test_recognized_message_skips_reingest(tmp_path):
                     'tags': ['animals', 'indoor', 'pet'],
                     'safety': {'nsfw': False, 'reason': 'безопасно'},
                 },
-                prompt_tokens=10,
-                completion_tokens=5,
-                total_tokens=15,
-                request_id='req-1',
+                {
+                    'prompt_tokens': 10,
+                    'completion_tokens': 5,
+                    'total_tokens': 15,
+                    'request_id': 'req-1',
+                    'endpoint': '/v1/responses',
+                },
             )
 
     bot._download_file = fake_download  # type: ignore[assignment]
@@ -418,10 +421,13 @@ async def test_recognized_edit_skips_reingest(tmp_path):
                     'tags': ['animals', 'indoor', 'pet'],
                     'safety': {'nsfw': False, 'reason': 'безопасно'},
                 },
-                prompt_tokens=10,
-                completion_tokens=5,
-                total_tokens=15,
-                request_id='req-2',
+                {
+                    'prompt_tokens': 10,
+                    'completion_tokens': 5,
+                    'total_tokens': 15,
+                    'request_id': 'req-2',
+                    'endpoint': '/v1/responses',
+                },
             )
 
     bot._download_file = fake_download  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- extend `OpenAIResponse` to expose a structured `usage` payload while keeping convenience accessors
- populate the usage metadata (tokens, endpoint, request id) in the OpenAI client response handler
- update usage logging, Supabase uploads, and tests to consume the new usage format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3f36445248332838f7c8bb429de21