### PR TITLE
Attempt EXIF load from path when metadata missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1984,9 +1984,13 @@ class Bot:
         try:
             with Image.open(image_source, mode="r") as img:
                 exif_bytes = img.info.get("exif")
-            if not exif_bytes:
-                return None
-            exif_dict = piexif.load(exif_bytes)
+            if exif_bytes:
+                exif_dict = piexif.load(exif_bytes)
+            else:
+                if isinstance(image_source, (str, Path)):
+                    exif_dict = piexif.load(str(image_source))
+                else:
+                    return None
         except Exception:
             logging.exception("Failed to parse EXIF metadata")
             return None


### PR DESCRIPTION
## Summary
- fall back to loading EXIF metadata from the file path when Image.open does not expose embedded data
- keep existing GPS conversion and error handling when metadata cannot be read

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3fc084a708332a1314948f92dc432