### PR TITLE
Update vision schema to new framing and weather enums

### DIFF
--- a/tests/test_vision_results.py
+++ b/tests/test_vision_results.py
@@ -51,16 +51,16 @@ def test_update_asset_persists_vision_results(db_connection):
         "guess_city": "Калининград",
         "location_confidence": 0.82,
         "landmarks": ["Кафедральный собор"],
-        "tags": ["architecture", "flowers", "cloudy"],
-        "framing": "wide shot",
+        "tags": ["architecture", "flowers", "overcast"],
+        "framing": "wide",
         "architecture_close_up": False,
         "architecture_wide": True,
-        "weather_image": "cloudy",
+        "weather_image": "overcast",
         "season_guess": "spring",
         "arch_style": {"label": "gothic", "confidence": 0.9},
         "safety": {"nsfw": False, "reason": "безопасно"},
         "category": "architecture",
-        "photo_weather": "cloudy",
+        "photo_weather": "overcast",
         "photo_weather_display": "пасмурно",
         "flower_varieties": ["роза"],
     }
@@ -95,7 +95,7 @@ def test_update_asset_persists_vision_results(db_connection):
     asset = data.get_asset(asset_id)
     assert asset is not None
     assert asset.vision_category == "architecture"
-    assert asset.vision_photo_weather == "cloudy"
+    assert asset.vision_photo_weather == "overcast"
     assert asset.vision_confidence == pytest.approx(0.82)
     assert asset.vision_results == payload
 
@@ -175,16 +175,13 @@ def test_asset_vision_schema_definition():
             "framing": {
                 "type": "string",
                 "description": (
-                    "Кадровка/ракурс снимка. Используй один из вариантов: close-up, medium shot, wide shot, detail, panorama, aerial shot."
-                ),
-                "enum": [
-                    "close-up",
-                    "medium shot",
-                    "wide shot",
-                    "detail",
-                    "panorama",
-                    "aerial shot",
-                ],
+                "Кадровка/ракурс снимка. Используй один из вариантов: close_up, medium, wide."
+            ),
+            "enum": [
+                "close_up",
+                "medium",
+                "wide",
+            ],
             },
             "architecture_close_up": {
                 "type": "boolean",
@@ -197,19 +194,17 @@ def test_asset_vision_schema_definition():
             "weather_image": {
                 "type": "string",
                 "description": (
-                    "Краткое описание погодных условий на фото (на английском). Выбирай из категорий: indoor, sunny, cloudy, rainy, snowy, foggy, stormy, twilight, night."
-                ),
-                "enum": [
-                    "indoor",
-                    "sunny",
-                    "cloudy",
-                    "rainy",
-                    "snowy",
-                    "foggy",
-                    "stormy",
-                    "twilight",
-                    "night",
-                ],
+                "Краткое описание погодных условий на фото (на английском). Выбирай из категорий: sunny, partly_cloudy, overcast, rain, snow, fog, night."
+            ),
+            "enum": [
+                "sunny",
+                "partly_cloudy",
+                "overcast",
+                "rain",
+                "snow",
+                "fog",
+                "night",
+            ],
             },
             "season_guess": {
                 "type": ["string", "null"],

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -84,15 +84,15 @@ async def _run_vision_job_collect_calls(
                 'caption': 'кот',
                 'objects': ['кот'],
                 'is_outdoor': False,
-                'framing': 'close-up',
+                'framing': 'close_up',
                 'guess_country': None,
                 'guess_city': None,
                 'location_confidence': 0.0,
                 'landmarks': [],
-                'tags': ['animals', 'indoor', 'pet'],
+                'tags': ['animals', 'sunny', 'pet'],
                 'architecture_close_up': False,
                 'architecture_wide': False,
-                'weather_image': 'indoor',
+                'weather_image': 'sunny',
                 'season_guess': None,
                 'arch_style': None,
                 'safety': {'nsfw': False, 'reason': 'безопасно'},
@@ -248,21 +248,21 @@ async def test_job_vision_enriches_weather_season_and_style(tmp_path, monkeypatc
 
     assert asset.vision_results is not None
     vision = asset.vision_results
-    assert vision['weather_final'] == 'rainy'
-    assert vision['weather_final_display'] == 'дождливо'
+    assert vision['weather_final'] == 'rain'
+    assert vision['weather_final_display'] == 'дождь'
     assert vision['season_final'] == 'autumn'
     assert vision['season_final_display'] == 'осень'
     assert vision['arch_style'] == {'label': 'Gothic', 'confidence': 0.65}
-    assert 'rainy' in vision['tags']
+    assert 'rain' in vision['tags']
 
     assert asset.vision_caption is not None
-    assert 'Погода: дождливо' in asset.vision_caption
+    assert 'Погода: дождь' in asset.vision_caption
     assert 'Сезон: осень' in asset.vision_caption
     assert 'Стиль: Gothic (≈65%)' in asset.vision_caption
 
     assert supabase_calls, 'supabase logging should be attempted'
     meta = supabase_calls[0]['meta']
-    assert meta['weather_final'] == 'rainy'
+    assert meta['weather_final'] == 'rain'
     assert meta['season_final'] == 'autumn'
     assert meta['arch_style'] == {'label': 'Gothic', 'confidence': 0.65}
 
@@ -499,15 +499,15 @@ async def test_recognized_message_skips_reingest(tmp_path):
                     'caption': 'кот',
                     'objects': ['кот'],
                     'is_outdoor': False,
-                    'framing': 'close-up',
+                    'framing': 'close_up',
                     'guess_country': None,
                     'guess_city': None,
                     'location_confidence': 0.0,
                     'landmarks': [],
-                    'tags': ['animals', 'indoor', 'pet'],
+                    'tags': ['animals', 'sunny', 'pet'],
                     'architecture_close_up': False,
                     'architecture_wide': False,
-                    'weather_image': 'indoor',
+                    'weather_image': 'sunny',
                     'season_guess': None,
                     'arch_style': None,
                     'safety': {'nsfw': False, 'reason': 'безопасно'},
@@ -606,7 +606,7 @@ async def test_recognized_message_skips_reingest(tmp_path):
         'message_id': recognized_mid,
         'date': int(datetime.utcnow().timestamp()),
         'chat': {'id': -100123},
-        'caption': 'Распознано: кот\nУверенность в локации: 0%\nОбстановка: в помещении\nНа улице: нет\nАрхитектура: нет\nОбъекты: кот\nТеги: animals, indoor, pet\nБезопасность: безопасно',
+        'caption': 'Распознано: кот\nУверенность в локации: 0%\nОбстановка: солнечно\nНа улице: нет\nАрхитектура: нет\nОбъекты: кот\nТеги: animals, sunny, pet\nБезопасность: безопасно',
         'photo': [
             {
                 'file_id': 'vision_small',
@@ -672,15 +672,15 @@ async def test_recognized_edit_skips_reingest(tmp_path):
                     'caption': 'кот',
                     'objects': ['кот'],
                     'is_outdoor': False,
-                    'framing': 'close-up',
+                    'framing': 'close_up',
                     'guess_country': None,
                     'guess_city': None,
                     'location_confidence': 0.0,
                     'landmarks': [],
-                    'tags': ['animals', 'indoor', 'pet'],
+                    'tags': ['animals', 'sunny', 'pet'],
                     'architecture_close_up': False,
                     'architecture_wide': False,
-                    'weather_image': 'indoor',
+                    'weather_image': 'sunny',
                     'season_guess': None,
                     'arch_style': None,
                     'safety': {'nsfw': False, 'reason': 'безопасно'},


### PR DESCRIPTION
## Summary
- align the asset vision schema with the new framing and weather token lists
- normalize and translate weather/framing outputs to the updated enums and adjust prompt guidance
- refresh vision-related tests and expectations for the revised values

## Testing
- pytest tests/test_vision_results.py tests/test_weather_new.py

------
https://chatgpt.com/codex/tasks/task_e_68e439e41d3c8332a0e8c5071c673a38