### PR TITLE
Ensure arch style confidence is nullable

### DIFF
--- a/main.py
+++ b/main.py
@@ -392,13 +392,13 @@ ASSET_VISION_V1_SCHEMA: dict[str, Any] = {
                     "minLength": 1,
                 },
                 "confidence": {
-                    "type": "number",
+                    "type": ["number", "null"],
                     "description": "Уверенность в определении стиля (0 — неизвестно, 1 — уверен).",
                     "minimum": 0,
                     "maximum": 1,
                 },
             },
-            "required": ["label"],
+            "required": ["label", "confidence"],
         },
         "safety": {
             "type": "object",
@@ -3110,14 +3110,12 @@ class Bot:
                             confidence_value = None
                     if confidence_value is not None:
                         confidence_value = min(max(confidence_value, 0.0), 1.0)
-                    arch_style = {"label": label}
-                    if confidence_value is not None:
-                        arch_style["confidence"] = confidence_value
+                    arch_style = {"label": label, "confidence": confidence_value}
                 else:
                     arch_style = None
             elif isinstance(arch_style_raw, str):
                 label = arch_style_raw.strip()
-                arch_style = {"label": label} if label else None
+                arch_style = {"label": label, "confidence": None} if label else None
             else:
                 arch_style = None
             usage = response.usage if isinstance(response.usage, dict) else {}


### PR DESCRIPTION
## Summary
- allow the arch_style confidence field to be null while still required in the schema
- normalize parsed vision results so confidence is always included, defaulting to None when missing
- extend vision result persistence tests to cover confidence retention and null handling

## Testing
- pytest tests/test_vision_results.py

------
https://chatgpt.com/codex/tasks/task_e_68e43cae92f88332930d1e4308081c17