### PR TITLE
Document strict schema normalization in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated the OpenAI Responses payload to use the latest `response_format` schema and
   ensured token usage metrics persist to Supabase with non-null totals.
+- OpenAI payloads now run through `strictify_schema`, enforcing required keys and null-tolerant
+  types to eliminate `invalid_json_schema` errors while normalizing nested objects and arrays so
+  operators can see why retries no longer fail with missing-property complaints.
 - `/set_assets_channel` now updates both channel roles for backward compatibility, while `publish_weather` only copies from the weather storage channel and leaves source messages untouched.
 - `guess_arch` overlays now scale to 10–16% of the shortest image side so custom PNG badges stay proportional across photo sizes.
 


### PR DESCRIPTION
## Summary
- document that the OpenAI payload now passes through strictify_schema to enforce required keys and null-tolerant types
- note that the helper normalizes nested structures so operators understand the reduction in missing-property retries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4443b59788332b3e87fbc33f6d87e