### PR TITLE
Refactor OpenAI image handling

### DIFF
--- a/imgio.py
+++ b/imgio.py
@@ -95,28 +95,6 @@ def _create_temp_file(prefix: str) -> Path:
     return Path(temp_name)
 
 
-def make_ai_derivative_to_temp(src_path: str | os.PathLike[str] | Path) -> Path:
-    source_path = Path(src_path)
-    max_side = _env_int("ASSETS_AI_MAX_SIDE", 2048)
-    image = _prepare_image(source_path, max_side=max_side)
-    temp_path = _create_temp_file("ai-")
-    try:
-        image.save(temp_path, format="JPEG", quality=88, progressive=True)
-    finally:
-        image.close()
-        gc.collect()
-    return temp_path
-
-
-def b64_data_url_from_file(path: str | os.PathLike[str] | Path) -> str:
-    file_path = Path(path)
-    data = file_path.read_bytes()
-    import base64
-
-    encoded = base64.b64encode(data).decode("ascii")
-    return f"data:image/jpeg;base64,{encoded}"
-
-
 def _iter_quality_steps(min_quality: int) -> list[int]:
     base_steps = [92, 88, 86]
     qualities = [q for q in base_steps if q >= min_quality]

--- a/main.py
+++ b/main.py
@@ -842,9 +842,20 @@ class Bot:
             send_path = cleanup_path
             content_type = "image/jpeg"
             mode = "reencoded"
-        filename = Path(local_path).name or "photo.jpg"
+        path_obj = Path(local_path)
+        filename = path_obj.name or "photo.jpg"
         if mode != "original":
-            filename = f"{Path(filename).stem or 'photo'}.jpg"
+            filename = f"{path_obj.stem or 'photo'}.jpg"
+        else:
+            normalized = {
+                "image/jpeg": ".jpg",
+                "image/jpg": ".jpg",
+                "image/png": ".png",
+                "image/webp": ".webp",
+            }
+            desired_suffix = normalized.get(content_type.lower()) if content_type else None
+            if desired_suffix and not filename.lower().endswith(desired_suffix):
+                filename = f"{path_obj.stem or 'photo'}{desired_suffix}"
         logging.info(
             "Publishing photo for chat %s via %s file (mime=%s size=%s)",
             chat_id,


### PR DESCRIPTION
## Summary
- embed original images directly in OpenAI requests by base64 encoding them and inferring MIME types, avoiding temporary derivatives
- drop unused derivative helpers and ensure Telegram uploads use filenames that match the image content type
- update OpenAI client tests to reflect the new data URL workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4fd1191a88332acc3e8cf21502984