### PR TITLE
Document flowers preview workflow in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Flowers rubric preview workflow that lets operators review candidates, regenerate media or captions, capture manual
+  instructions, and choose the final publication destinations, backed by automated tests covering regeneration, instruction
+  capture, and delivery flows.
 - Supabase integration that mirrors OpenAI token usage into `token_usage` via `SUPABASE_URL`/`SUPABASE_KEY`, including strict JSON serialization of metadata and structured `log_token_usage` log lines mirroring the payload when inserts succeed or fail.
 - `/help` command that delivers a Markdown help guide with links to admin-interface workflows and manual button instructions.
 - Dual asset channel support with new `/set_weather_assets_channel` and `/set_recognition_channel` commands plus migration `0014_split_asset_channels.sql` that creates the recognition table and marks asset origins.


### PR DESCRIPTION
## Summary
- note the new flowers rubric preview workflow in the unreleased changelog section
- highlight its operator controls and the automated coverage backing the flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e511eeb1108332b5098dcf44aec03d