### PR TITLE
Ensure photo reposts delete original message

### DIFF
--- a/main.py
+++ b/main.py
@@ -3662,7 +3662,9 @@ class Bot:
                         "caption": caption_text or None,
                     },
                 )
-                if not resp.get("ok"):
+                if resp.get("ok"):
+                    delete_original_after_post = True
+                else:
                     logging.error(
                         "Vision job %s failed to copy message for asset %s: %s",
                         job.id,
@@ -3680,7 +3682,9 @@ class Bot:
                         },
                     )
                     method_used = fallback_method
-                    if not resp.get("ok"):
+                    if resp.get("ok"):
+                        delete_original_after_post = fallback_method == "sendPhoto"
+                    else:
                         logging.error(
                             "Vision job %s failed to publish result for asset %s via %s: %s",
                             job.id,

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -201,6 +201,8 @@ async def test_job_vision_skips_exif_debug_by_default(tmp_path, monkeypatch):
     )
     assert any(call['method'] == 'copyMessage' for call in calls)
     assert not any(call['method'] == 'sendMessage' for call in calls)
+    delete_calls = [call for call in calls if call['method'] == 'deleteMessage']
+    assert delete_calls, 'original photo message should be deleted after publishing'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure vision photo reposts flag original messages for deletion after successful copy/sendPhoto
- extend photo vision test to confirm Telegram deleteMessage is invoked

## Testing
- `pytest tests/test_weather_new.py::test_job_vision_skips_exif_debug_by_default`


------
https://chatgpt.com/codex/tasks/task_e_68e5195ab8c48332ab498906f885e95b