### PR TITLE
Handle low-confidence architecture style captions

### DIFF
--- a/main.py
+++ b/main.py
@@ -3558,12 +3558,21 @@ class Bot:
             caption_lines.append(f"Сезон: {season_caption_display}")
             if arch_style and arch_style.get("label"):
                 confidence_value = arch_style.get("confidence")
-                if isinstance(confidence_value, (int, float)) and confidence_value >= 0.4:
-                    confidence_pct = int(round(float(confidence_value) * 100))
+                style_line = f"Стиль: {arch_style['label']}"
+                confidence_note: str
+                if isinstance(confidence_value, (int, float)) and math.isfinite(
+                    confidence_value
+                ):
+                    confidence_float = float(confidence_value)
+                    confidence_pct = int(round(confidence_float * 100))
                     confidence_pct = max(0, min(100, confidence_pct))
-                    caption_lines.append(
-                        f"Стиль: {arch_style['label']} (≈{confidence_pct}%)"
-                    )
+                    if confidence_float >= 0.4:
+                        confidence_note = f"(≈{confidence_pct}%)"
+                    else:
+                        confidence_note = f"(низкая уверенность ≈{confidence_pct}%)"
+                else:
+                    confidence_note = "(уверенность неизвестна)"
+                caption_lines.append(f"{style_line} {confidence_note}".strip())
             if landmarks:
                 caption_lines.append("Ориентиры: " + ", ".join(landmarks))
             if flower_varieties:


### PR DESCRIPTION
## Summary
- always emit the architecture style line with an explicit confidence note in captions
- cover low-confidence styles with a dedicated regression test

## Testing
- pytest tests/test_weather_new.py::test_job_vision_enriches_weather_season_and_style
- pytest tests/test_weather_new.py::test_job_vision_includes_low_conf_arch_style

------
https://chatgpt.com/codex/tasks/task_e_68e54fecd394833296d4c458cff2605a