### PR TITLE
Replace spoiler caption entity with expandable quote

### DIFF
--- a/main.py
+++ b/main.py
@@ -3591,9 +3591,10 @@ class Bot:
             if caption_text:
                 caption_entities = [
                     {
-                        "type": "spoiler",
+                        "type": "blockquote",
                         "offset": 0,
                         "length": _utf16_length(caption_text),
+                        "is_expandable": True,
                     }
                 ]
             location_log_parts: list[str] = []

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -495,7 +495,10 @@ async def test_job_vision_caption_entities_utf16_length(tmp_path, monkeypatch):
     caption_entities = payload.get('caption_entities')
     assert isinstance(caption_entities, list) and caption_entities
     expected_length = len(caption_text.encode('utf-16-le')) // 2
-    assert caption_entities[0]['length'] == expected_length
+    first_entity = caption_entities[0]
+    assert first_entity['type'] == 'blockquote'
+    assert first_entity['length'] == expected_length
+    assert first_entity.get('is_expandable') is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update the generated caption entity to use an expandable blockquote instead of a spoiler
- adjust the vision caption entity test to expect the expandable blockquote metadata

## Testing
- pytest tests/test_weather_new.py::test_job_vision_caption_entities_utf16_length

------
https://chatgpt.com/codex/tasks/task_e_68e55786967083328b072aa0954bfb0b