### PR TITLE
Normalize flower tags in vision processing

### DIFF
--- a/data_access.py
+++ b/data_access.py
@@ -692,6 +692,7 @@ class DataAccess:
                         continue
                     seen.add(text)
                     normalized_tags.append(text)
+            normalized_tag_set = set(normalized_tags)
             category = (
                 result.get("category")
                 or result.get("caption")
@@ -721,7 +722,7 @@ class DataAccess:
                 photo_weather = str(result.get("photo_weather")).strip() or None
             flowers_raw = result.get("flower_varieties")
             if flowers_raw is None:
-                if "flowers" in normalized_tags:
+                if normalized_tag_set.intersection({"flowers", "flower"}):
                     objects = result.get("objects")
                     if isinstance(objects, list):
                         extracted: list[str] = []

--- a/main.py
+++ b/main.py
@@ -3467,7 +3467,8 @@ class Bot:
             category = self._derive_primary_scene(caption, tags)
             rubric_id = self._resolve_rubric_id_for_category(category)
             flower_varieties: list[str] = []
-            if "flowers" in tags:
+            normalized_tag_set = {tag.lower() for tag in tags if tag}
+            if normalized_tag_set.intersection({"flowers", "flower"}):
                 flower_varieties = [obj for obj in objects if obj]
             location_parts: list[str] = []
             existing_lower: set[str] = set()
@@ -6882,9 +6883,10 @@ class Bot:
 
     def _derive_primary_scene(self, primary_scene: str, tags: Sequence[str]) -> str:
         normalized_tags = [tag.lower() for tag in tags if tag]
-        if "architecture" in normalized_tags:
+        normalized_set = set(normalized_tags)
+        if "architecture" in normalized_set:
             return "architecture"
-        if "flowers" in normalized_tags:
+        if normalized_set.intersection({"flowers", "flower"}):
             return "flowers"
         if normalized_tags:
             return normalized_tags[0]


### PR DESCRIPTION
## Summary
- normalize singular and plural flower tags when deriving the vision category and flower varieties
- store flower varieties for assets tagged with either "flower" or "flowers" and cover the singular case with a regression test

## Testing
- pytest tests/test_rubrics.py::test_vision_job_handles_singular_flower_tag -q

------
https://chatgpt.com/codex/tasks/task_e_68e559b9ff788332ab6964b43540ff2b