### PR TITLE
Allow flowers rubric to send single-photo drops

### DIFF
--- a/migrations/0016_default_rubrics.py
+++ b/migrations/0016_default_rubrics.py
@@ -8,7 +8,7 @@ DEFAULT_RUBRICS = {
         "config": {
             "enabled": False,
             "schedules": [],
-            "assets": {"min": 4, "max": 6, "categories": ["flowers"]},
+            "assets": {"min": 1, "max": 6, "categories": ["flowers"]},
         },
     },
     "guess_arch": {


### PR DESCRIPTION
## Summary
- lower the default flowers rubric minimum asset count to one in the preset and seed data
- validate flower asset limits via a shared helper, reuse the configured minimum in operator notices, and send single-photo drops with sendPhoto across publish and preview flows
- expand rubric tests to cover one-to-three photo cases and the single-photo preview path

## Testing
- pytest tests/test_rubrics.py


------
https://chatgpt.com/codex/tasks/task_e_68e564c739f08332aaefa9d7ab12e102