### PR TITLE
Use expandable blockquote entity for vision captions

### DIFF
--- a/main.py
+++ b/main.py
@@ -3711,10 +3711,9 @@ class Bot:
             if caption_text:
                 caption_entities = [
                     {
-                        "type": "blockquote",
+                        "type": "expandable_blockquote",
                         "offset": 0,
                         "length": _utf16_length(caption_text),
-                        "is_expandable": True,
                     }
                 ]
             location_log_parts: list[str] = []

--- a/tests/test_weather_new.py
+++ b/tests/test_weather_new.py
@@ -526,9 +526,9 @@ async def test_job_vision_caption_entities_utf16_length(tmp_path, monkeypatch):
     assert isinstance(caption_entities, list) and caption_entities
     expected_length = len(caption_text.encode('utf-16-le')) // 2
     first_entity = caption_entities[0]
-    assert first_entity['type'] == 'blockquote'
+    assert first_entity['type'] == 'expandable_blockquote'
     assert first_entity['length'] == expected_length
-    assert first_entity.get('is_expandable') is True
+    assert 'is_expandable' not in first_entity
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- switch vision caption entities to use the expandable_blockquote type required by the Bot API
- update tests to assert the new entity type and ensure no legacy fields remain

## Testing
- pytest tests/test_weather_new.py -k caption_entities_utf16_length

------
https://chatgpt.com/codex/tasks/task_e_68e56d8d57b483328138c2584b68beab