### PR TITLE
Handle convertible image documents in flowers preview

### DIFF
--- a/main.py
+++ b/main.py
@@ -7136,6 +7136,8 @@ class Bot:
         if kind == "photo":
             return "photo", missing_file
         if kind == "document":
+            if self._is_convertible_image_document(asset):
+                return "photo", True
             if is_photo_mime(asset.mime_type):
                 return "photo", True
             return "document", missing_file


### PR DESCRIPTION
## Summary
- treat document assets with image-style filenames as photos so they trigger re-uploads when needed
- add coverage ensuring convertible documents use the photo workflow and keep the document fallback using a non-image filename

## Testing
- pytest tests/test_rubrics.py::test_flowers_preview_document_media_paths tests/test_rubrics.py::test_flowers_preview_document_with_image_filename

------
https://chatgpt.com/codex/tasks/task_e_68e58658b0dc8332bd4e2057347f4c64