### PR TITLE
Ensure Kaliningrad weather mention in flowers block

### DIFF
--- a/main.py
+++ b/main.py
@@ -9576,15 +9576,33 @@ class Bot:
         }
 
     def _format_flowers_cities_for_weather(self, cities: Sequence[str], fallback: str) -> str:
-        unique = [str(city).strip() for city in cities if str(city or "").strip()]
-        if not unique:
-            return fallback
-        unique = sorted(dict.fromkeys(unique))
-        if len(unique) == 1:
-            return unique[0]
-        if len(unique) == 2:
-            return f"{unique[0]} и {unique[1]}"
-        return ", ".join(unique[:-1]) + f" и {unique[-1]}"
+        base_city = (fallback or "").strip() or "Калининград"
+        base_key = base_city.casefold()
+        shooting_locations: list[str] = []
+        seen: set[str] = set()
+        for raw_city in cities:
+            city = str(raw_city or "").strip()
+            if not city:
+                continue
+            key = city.casefold()
+            if key == base_key:
+                continue
+            if key in seen:
+                continue
+            seen.add(key)
+            shooting_locations.append(city)
+
+        if not shooting_locations:
+            return base_city
+
+        if len(shooting_locations) == 1:
+            locations = shooting_locations[0]
+        elif len(shooting_locations) == 2:
+            locations = f"{shooting_locations[0]} и {shooting_locations[1]}"
+        else:
+            locations = ", ".join(shooting_locations[:-1]) + f" и {shooting_locations[-1]}"
+
+        return f"{base_city} (съёмка: {locations})"
 
     def _compose_flowers_weather_block(
         self, cities: Sequence[str]

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -1505,7 +1505,7 @@ async def test_generate_flowers_uses_gpt_4o(tmp_path):
     _insert_rubric(bot, "flowers", config, rubric_id=1)
     rubric = bot.data.get_rubric_by_code("flowers")
     _seed_weather(bot)
-    weather_block = bot._compose_flowers_weather_block(["Москва"])  # type: ignore[attr-defined]
+    weather_block = bot._compose_flowers_weather_block(["Baltiisk"])  # type: ignore[attr-defined]
 
     calls: list[dict[str, Any]] = []
 
@@ -1551,7 +1551,7 @@ async def test_generate_flowers_uses_gpt_4o(tmp_path):
         exif_present=False,
         latitude=None,
         longitude=None,
-        city="Москва",
+        city="Baltiisk",
         country="Россия",
         author_user_id=None,
         author_username=None,
@@ -1591,6 +1591,9 @@ async def test_generate_flowers_uses_gpt_4o(tmp_path):
     assert "План:" in user_prompt
     assert "Правила" in user_prompt
     assert "photo_dependent" in user_prompt
+    assert weather_block["city"] is not None
+    assert weather_block["city"]["name"] in weather_block["line"]
+    assert weather_block["city"]["name"].casefold() == "kaliningrad"
 
     await bot.close()
 


### PR DESCRIPTION
## Summary
- always include the Kaliningrad weather city while separating shooting locations in the flowers weather block
- adjust the flowers rubric test asset to come from Baltiisk and assert that the weather line still references the Kaliningrad snapshot

## Testing
- pytest tests/test_rubrics.py -k flowers -q

------
https://chatgpt.com/codex/tasks/task_e_68e64a4682148332b47320ffa8c62b0f