### PR TITLE
Use daily weather metrics for weather trend summaries

### DIFF
--- a/main.py
+++ b/main.py
@@ -9709,17 +9709,36 @@ class Bot:
         if wind_detail:
             details.append(f"ветер {wind_detail}")
         snapshot["detail"] = ", ".join(details)
-        snapshot["trend_temperature"] = self._positive_temperature_trend(
-            snapshot["day_temperature"]
+        trend_temperature_value = (
+            snapshot.get("day_temperature")
             if snapshot.get("day_temperature") is not None
-            else snapshot["temperature"],
+            else snapshot.get("temperature")
+        )
+        trend_wind_value = (
+            snapshot.get("day_wind")
+            if snapshot.get("day_wind") is not None
+            else snapshot.get("wind_speed")
+        )
+        snapshot["trend_temperature_value"] = trend_temperature_value
+        snapshot["trend_wind_value"] = trend_wind_value
+        snapshot["trend_temperature_previous_value"] = snapshot.get(
+            "previous_temperature"
+        )
+        snapshot["trend_wind_previous_value"] = snapshot.get("previous_wind")
+
+        snapshot["trend_temperature"] = self._positive_temperature_trend(
+            trend_temperature_value,
             snapshot.get("previous_temperature"),
         )
         snapshot["trend_wind"] = self._positive_wind_trend(
-            snapshot["day_wind"] if snapshot.get("day_wind") is not None else snapshot["wind_speed"],
+            trend_wind_value,
             snapshot.get("previous_wind"),
         )
-        trends = [piece for piece in [snapshot["trend_temperature"], snapshot["trend_wind"]] if piece]
+        trends = [
+            piece
+            for piece in (snapshot["trend_temperature"], snapshot["trend_wind"])
+            if piece
+        ]
         snapshot["trend_summary"] = " и ".join(trends)
         if snapshot["trend_summary"]:
             snapshot["positive_intro"] = "Утро радует"

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -64,7 +64,7 @@ def _seed_weather(bot: Bot) -> None:
 
 
 @pytest.mark.asyncio
-async def test_build_flowers_plan_uses_daily_weather_trend(tmp_path):
+async def test_build_flowers_plan_uses_single_rotating_pattern(tmp_path):
     bot = Bot("dummy", str(tmp_path / "db.sqlite"))
     config = {"enabled": True, "assets": {"min": 1, "max": 1}}
     _insert_rubric(bot, "flowers", config, rubric_id=1)
@@ -94,9 +94,17 @@ async def test_build_flowers_plan_uses_daily_weather_trend(tmp_path):
 
     weather_block = bot._compose_flowers_weather_block(["Kaliningrad"])
     assert weather_block is not None
+    city_snapshot = weather_block.get("city")
+    assert city_snapshot is not None
     summary = weather_block.get("trend_summary")
-    assert summary == "свежесть бодрит — около 4°C и ветер стал спокойнее — около 5 м/с"
+    assert (
+        summary
+        == "свежесть бодрит — около 4°C и ветер стал спокойнее — около 5 м/с"
+    )
+    assert city_snapshot["trend_temperature_value"] == 4.0
+    assert city_snapshot["trend_wind_value"] == 4.8
     assert "12°C" not in summary
+    assert "12°C" in (city_snapshot.get("detail") or "")
 
     await bot.close()
 


### PR DESCRIPTION
## Summary
- derive weather trend inputs from daily snapshots before falling back to hourly readings
- expose the derived trend values on the city snapshot and build the trend summary from them
- extend the flowers weather trend test to verify daily metrics drive the summary while hourly data stays in the detail

## Testing
- `pytest tests/test_rubrics.py::test_build_flowers_plan_uses_single_rotating_pattern`


------
https://chatgpt.com/codex/tasks/task_e_68e663982d4483328207323de003d0c9